### PR TITLE
make Blackboard variable IDs private to the navigators

### DIFF
--- a/nav2_bt_navigator/src/navigators/navigate_through_poses.cpp
+++ b/nav2_bt_navigator/src/navigators/navigate_through_poses.cpp
@@ -31,11 +31,11 @@ NavigateThroughPosesNavigator::configure(
   auto node = parent_node.lock();
 
   goals_blackboard_id_ =
-    node->declare_or_get_parameter("goals_blackboard_id", std::string("goals"));
+    node->declare_or_get_parameter(getName() + ".goals_blackboard_id", std::string("goals"));
   path_blackboard_id_ =
-    node->declare_or_get_parameter("path_blackboard_id", std::string("path"));
+    node->declare_or_get_parameter(getName() + ".path_blackboard_id", std::string("path"));
   waypoint_statuses_blackboard_id_ =
-    node->declare_or_get_parameter("waypoint_statuses_blackboard_id",
+    node->declare_or_get_parameter(getName() + ".waypoint_statuses_blackboard_id",
       std::string("waypoint_statuses"));
 
   // Odometry smoother object for getting current speed

--- a/nav2_bt_navigator/src/navigators/navigate_to_pose.cpp
+++ b/nav2_bt_navigator/src/navigators/navigate_to_pose.cpp
@@ -29,10 +29,10 @@ NavigateToPoseNavigator::configure(
   start_time_ = rclcpp::Time(0);
   auto node = parent_node.lock();
 
-  goal_blackboard_id_ =
-    node->declare_or_get_parameter("goal_blackboard_id", std::string("goal"));
-  path_blackboard_id_ =
-    node->declare_or_get_parameter("path_blackboard_id", std::string("path"));
+  goal_blackboard_id_ = node->declare_or_get_parameter(getName() + ".goal_blackboard_id",
+      std::string("goal"));
+  path_blackboard_id_ = node->declare_or_get_parameter(getName() + ".path_blackboard_id",
+      std::string("path"));
 
   // Odometry smoother object for getting current speed
   odom_smoother_ = odom_smoother;


### PR DESCRIPTION
Cherry-pick https://github.com/ros-navigation/navigation2/pull/5466 to out development branch, as we have slightly diverged

Move the `xx_blackboard_id` parameters to each navigator's namespace. This avoids clashes with other navigators which have the same parameter, but uses a different ID.

See PR in main repo for testing
