### PR TITLE
[mppi] Don't reset zone-based speed limits

### DIFF
--- a/nav2_mppi_controller/src/optimizer.cpp
+++ b/nav2_mppi_controller/src/optimizer.cpp
@@ -121,7 +121,8 @@ void Optimizer::getParams()
   s.constraints = s.base_constraints;
 
   setMotionModel(motion_model_name);
-  parameters_handler_->addPostCallback([this]() {reset();});
+  // Don't reset zone-based speed limits after params changes
+  parameters_handler_->addPostCallback([this]() { reset(false); });
 
   double controller_frequency;
   getParentParam(controller_frequency, "controller_frequency", 0.0, ParameterType::Static);
@@ -238,7 +239,7 @@ bool Optimizer::fallback(bool fail)
     return false;
   }
 
-  reset();
+  reset(false /*Don't reset zone-based speed limits after fallback*/);
 
   if (++counter > settings_.retry_attempt_limit) {
     counter = 0;

--- a/nav2_mppi_controller/src/trajectory_visualizer.cpp
+++ b/nav2_mppi_controller/src/trajectory_visualizer.cpp
@@ -117,8 +117,7 @@ void TrajectoryVisualizer::add(
   for (size_t i = 0; i < n_rows; i += trajectory_step_) {
     sorted_costs.emplace_back(i, trajectories.costs(i));
   }
-  std::sort(sorted_costs.begin(), sorted_costs.end(),
-            [](const auto & a, const auto & b) { return a.second < b.second; });
+  std::sort(sorted_costs.begin(), sorted_costs.end(), [](const auto& a, const auto& b) { return a.second < b.second; });
 
   const float step = 1.0f / static_cast<float>(sorted_costs.size());
   float color_component = 1.0f;


### PR DESCRIPTION
Fixes an issue that the zone-based speed limits are reset when params are changed or when the controller fails (on fallback)