### PR TITLE
Add MPPI visualization

### DIFF
--- a/nav2_bringup/params/nav2_params.yaml
+++ b/nav2_bringup/params/nav2_params.yaml
@@ -151,12 +151,18 @@ controller_server:
       temperature: 0.3
       gamma: 0.015
       motion_model: "DiffDrive"
-      visualize: true
-      publish_optimal_trajectory: true
       regenerate_noises: true
-      TrajectoryVisualizer:
+      Visualization:
+        publish_critics_stats: false
+        publish_optimal_trajectory_msg: false
+        publish_transformed_path: false
+        publish_trajectories_with_total_cost: false
+        publish_trajectories_with_individual_cost: false
+        publish_optimal_footprints: false
+        publish_optimal_path: false
         trajectory_step: 5
         time_step: 3
+        footprint_downsample_factor: 3
       TrajectoryValidator:
         # The validator can be configured with additional parameters if needed.
         plugin: "mppi::DefaultOptimalTrajectoryValidator"

--- a/nav2_mppi_controller/include/nav2_mppi_controller/controller.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/controller.hpp
@@ -104,28 +104,14 @@ public:
   void setSpeedLimit(const double & speed_limit, const bool & percentage) override;
 
 protected:
-  /**
-    * @brief Visualize trajectories
-    * @param cmd_stamp Command stamp
-    * @param optimal_trajectory Optimal trajectory, if already computed
-    */
-  void visualize(
-    const builtin_interfaces::msg::Time & cmd_stamp,
-    const Eigen::ArrayXXf & optimal_trajectory);
-
   std::string name_;
   nav2::LifecycleNode::WeakPtr parent_;
   rclcpp::Logger logger_{rclcpp::get_logger("MPPIController")};
   std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros_;
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
-  nav2::Publisher<nav2_msgs::msg::Trajectory>::SharedPtr opt_traj_pub_;
-
   std::unique_ptr<ParametersHandler> parameters_handler_;
   Optimizer optimizer_;
   TrajectoryVisualizer trajectory_visualizer_;
-
-  bool visualize_;
-  bool publish_optimal_trajectory_;
 };
 
 }  // namespace nav2_mppi_controller

--- a/nav2_mppi_controller/include/nav2_mppi_controller/critic_data.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/critic_data.hpp
@@ -18,6 +18,8 @@
 #include <Eigen/Dense>
 
 #include <memory>
+#include <string>
+#include <utility>
 #include <vector>
 
 #include "geometry_msgs/msg/pose_stamped.hpp"
@@ -44,6 +46,7 @@ struct CriticData
   const geometry_msgs::msg::Pose & goal;
 
   Eigen::ArrayXf & costs;
+  std::optional<std::vector<std::pair<std::string, Eigen::ArrayXf>>> individual_critics_cost;
   float & model_dt;
 
   bool fail_flag;

--- a/nav2_mppi_controller/include/nav2_mppi_controller/critic_function.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/critic_function.hpp
@@ -70,7 +70,9 @@ public:
     ParametersHandler * param_handler)
   {
     parent_ = parent;
-    logger_ = parent_.lock()->get_logger();
+    auto node = parent_.lock();
+    logger_ = node->get_logger();
+    clock_ = node->get_clock();
     name_ = name;
     parent_name_ = parent_name;
     costmap_ros_ = costmap_ros;
@@ -111,6 +113,7 @@ protected:
 
   ParametersHandler * parameters_handler_;
   rclcpp::Logger logger_{rclcpp::get_logger("MPPIController")};
+  rclcpp::Clock::SharedPtr clock_;
 };
 
 }  // namespace mppi::critics

--- a/nav2_mppi_controller/include/nav2_mppi_controller/critic_manager.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/critic_manager.hpp
@@ -99,6 +99,7 @@ protected:
 
   nav2::Publisher<nav2_msgs::msg::CriticsStats>::SharedPtr critics_effect_pub_;
   bool publish_critics_stats_;
+  bool visualize_per_critic_costs_;
 
   rclcpp::Logger logger_{rclcpp::get_logger("MPPIController")};
 };

--- a/nav2_mppi_controller/include/nav2_mppi_controller/critics/path_align_critic.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/critics/path_align_critic.hpp
@@ -18,6 +18,9 @@
 #include "nav2_mppi_controller/critic_function.hpp"
 #include "nav2_mppi_controller/models/state.hpp"
 #include "nav2_mppi_controller/tools/utils.hpp"
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+#include "nav2_ros_common/publisher.hpp"
 
 namespace mppi::critics
 {
@@ -52,6 +55,9 @@ protected:
   bool use_path_orientations_{false};
   unsigned int power_{0};
   float weight_{0};
+
+  bool visualize_furthest_point_{false};
+  nav2::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr furthest_point_pub_;
 };
 
 }  // namespace mppi::critics

--- a/nav2_mppi_controller/include/nav2_mppi_controller/critics/path_angle_critic.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/critics/path_angle_critic.hpp
@@ -20,6 +20,9 @@
 #include "nav2_mppi_controller/models/state.hpp"
 #include "nav2_mppi_controller/tools/utils.hpp"
 #include "nav2_core/controller_exceptions.hpp"
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+#include "nav2_ros_common/publisher.hpp"
 
 namespace mppi::critics
 {
@@ -81,6 +84,9 @@ protected:
 
   unsigned int power_{0};
   float weight_{0};
+
+  bool visualize_furthest_point_{false};
+  nav2::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr furthest_point_pub_;
 };
 
 }  // namespace mppi::critics

--- a/nav2_mppi_controller/include/nav2_mppi_controller/critics/path_follow_critic.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/critics/path_follow_critic.hpp
@@ -19,6 +19,9 @@
 #include "nav2_mppi_controller/critic_function.hpp"
 #include "nav2_mppi_controller/models/state.hpp"
 #include "nav2_mppi_controller/tools/utils.hpp"
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+#include "nav2_ros_common/publisher.hpp"
 
 namespace mppi::critics
 {
@@ -53,6 +56,9 @@ protected:
 
   unsigned int power_{0};
   float weight_{0};
+
+  bool visualize_furthest_point_{false};
+  nav2::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr furthest_point_pub_;
 };
 
 }  // namespace mppi::critics

--- a/nav2_mppi_controller/include/nav2_mppi_controller/optimizer.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/optimizer.hpp
@@ -20,6 +20,8 @@
 #include <string>
 #include <memory>
 #include <tuple>
+#include <utility>
+#include <vector>
 
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 
@@ -117,6 +119,28 @@ public:
    * @return Optimal control sequence
    */
   const models::ControlSequence & getOptimalControlSequence();
+
+  /**
+   * @brief Get the costs for trajectories for visualization
+   * @return Costs array
+   */
+  const Eigen::ArrayXf & getCosts() const
+  {
+    return costs_;
+  }
+
+  /**
+   * @brief Get the per-critic costs for trajectories for visualization
+   * @return Vector of (critic_name, costs) pairs
+   */
+  const std::vector<std::pair<std::string, Eigen::ArrayXf>> & getCriticCosts() const
+  {
+    if (critics_data_.individual_critics_cost) {
+      return *critics_data_.individual_critics_cost;
+    }
+    static const std::vector<std::pair<std::string, Eigen::ArrayXf>> empty;
+    return empty;
+  }
 
   /**
    * @brief Set the maximum speed based on the speed limits callback
@@ -290,7 +314,7 @@ protected:
 
   CriticData critics_data_ = {
     state_, generated_trajectories_, path_, goal_,
-    costs_, settings_.model_dt, false, nullptr, nullptr,
+    costs_, std::nullopt, settings_.model_dt, false, nullptr, nullptr,
     std::nullopt, std::nullopt};  /// Caution, keep references
 
   rclcpp::Logger logger_{rclcpp::get_logger("MPPIController")};

--- a/nav2_mppi_controller/include/nav2_mppi_controller/tools/trajectory_visualizer.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/tools/trajectory_visualizer.hpp
@@ -98,7 +98,6 @@ public:
 
   /**
     * @brief Visualize all trajectory data in one call
-    * @param plan Transformed plan to visualize
     * @param optimal_trajectory Optimal trajectory
     * @param control_sequence Control sequence for optimal trajectory
     * @param model_dt Model time step
@@ -109,7 +108,6 @@ public:
     * @param critic_costs Per-critic costs for each trajectory
     */
   void visualize(
-    nav_msgs::msg::Path plan,
     const Eigen::ArrayXXf & optimal_trajectory,
     const models::ControlSequence & control_sequence,
     float model_dt,
@@ -121,9 +119,8 @@ public:
 
   /**
     * @brief Visualize without optimizer (for testing)
-    * @param plan Transformed plan to visualize
     */
-  void visualize(nav_msgs::msg::Path plan);
+  void visualize();
 
   /**
     * @brief Reset object

--- a/nav2_mppi_controller/include/nav2_mppi_controller/tools/trajectory_visualizer.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/tools/trajectory_visualizer.hpp
@@ -19,14 +19,20 @@
 
 #include <memory>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include "nav_msgs/msg/path.hpp"
+#include "nav2_msgs/msg/trajectory.hpp"
 #include "nav2_ros_common/lifecycle_node.hpp"
+#include "nav2_costmap_2d/costmap_2d_ros.hpp"
+#include "nav2_costmap_2d/footprint.hpp"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 
 #include "nav2_mppi_controller/tools/parameters_handler.hpp"
 #include "nav2_mppi_controller/tools/utils.hpp"
 #include "nav2_mppi_controller/models/trajectories.hpp"
+#include "nav2_mppi_controller/models/control_sequence.hpp"
 
 namespace mppi
 {
@@ -78,15 +84,46 @@ public:
     const builtin_interfaces::msg::Time & cmd_stamp);
 
   /**
-    * @brief Add candidate trajectories to visualize
+    * @brief Add candidate trajectories with costs to visualize
     * @param trajectories Candidate trajectories
+    * @param total_costs Total cost array for each trajectory
+    * @param individual_critics_cost Optional vector of (critic_name, cost_array) pairs for per-critic visualization
+    * @param cmd_stamp Timestamp for the markers
     */
-  void add(const models::Trajectories & trajectories, const std::string & marker_namespace);
+  void add(
+    const models::Trajectories & trajectories,
+    const Eigen::ArrayXf & total_costs,
+    const std::vector<std::pair<std::string, Eigen::ArrayXf>> & individual_critics_cost = {},
+    const builtin_interfaces::msg::Time & cmd_stamp = builtin_interfaces::msg::Time());
 
   /**
-    * @brief Visualize the plan
+    * @brief Visualize all trajectory data in one call
+    * @param plan Transformed plan to visualize
+    * @param optimal_trajectory Optimal trajectory
+    * @param control_sequence Control sequence for optimal trajectory
+    * @param model_dt Model time step
+    * @param stamp Timestamp for the visualization
+    * @param costmap_ros Costmap ROS pointer
+    * @param candidate_trajectories Generated candidate trajectories
+    * @param costs Total costs for each trajectory
+    * @param critic_costs Per-critic costs for each trajectory
     */
-  void visualize();
+  void visualize(
+    nav_msgs::msg::Path plan,
+    const Eigen::ArrayXXf & optimal_trajectory,
+    const models::ControlSequence & control_sequence,
+    float model_dt,
+    const builtin_interfaces::msg::Time & stamp,
+    std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros,
+    const models::Trajectories & candidate_trajectories,
+    const Eigen::ArrayXf & costs,
+    const std::vector<std::pair<std::string, Eigen::ArrayXf>> & critic_costs);
+
+  /**
+    * @brief Visualize without optimizer (for testing)
+    * @param plan Transformed plan to visualize
+    */
+  void visualize(nav_msgs::msg::Path plan);
 
   /**
     * @brief Reset object
@@ -94,10 +131,37 @@ public:
   void reset();
 
 protected:
+  /**
+    * @brief Create trajectory markers with cost-based coloring
+    * @param trajectories Set of trajectories to visualize
+    * @param costs Cost array for each trajectory
+    * @param ns Namespace for the markers
+    * @param cmd_stamp Timestamp for the markers
+    */
+  void createTrajectoryMarkers(
+    const models::Trajectories & trajectories,
+    const Eigen::ArrayXf & costs,
+    const std::string & ns,
+    const builtin_interfaces::msg::Time & cmd_stamp);
+
+  /**
+    * @brief Create footprint markers from trajectory
+    * @param trajectory Optimal trajectory
+    * @param header Message header
+    * @param costmap_ros Costmap ROS pointer for footprint and frame information
+    * @return MarkerArray containing footprint polygons
+    */
+  visualization_msgs::msg::MarkerArray createFootprintMarkers(
+    const Eigen::ArrayXXf & trajectory,
+    const std_msgs::msg::Header & header,
+    std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros);
+
   std::string frame_id_;
   nav2::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr
     trajectories_publisher_;
   nav2::Publisher<nav_msgs::msg::Path>::SharedPtr optimal_path_pub_;
+  nav2::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr optimal_footprints_pub_;
+  nav2::Publisher<nav2_msgs::msg::Trajectory>::SharedPtr optimal_trajectory_msg_pub_;
 
   std::unique_ptr<nav_msgs::msg::Path> optimal_path_;
   std::unique_ptr<visualization_msgs::msg::MarkerArray> points_;
@@ -107,6 +171,13 @@ protected:
 
   size_t trajectory_step_{0};
   size_t time_step_{0};
+  bool publish_trajectories_with_total_cost_{false};
+  bool publish_trajectories_with_individual_cost_{false};
+  bool publish_optimal_footprints_{false};
+  bool publish_optimal_trajectory_msg_{false};
+  bool publish_transformed_path_{false};
+  bool publish_optimal_path_{false};
+  int footprint_downsample_factor_{3};
 
   rclcpp::Logger logger_{rclcpp::get_logger("MPPIController")};
 };

--- a/nav2_mppi_controller/src/controller.cpp
+++ b/nav2_mppi_controller/src/controller.cpp
@@ -36,20 +36,12 @@ void MPPIController::configure(
   auto node = parent_.lock();
   // Get high-level controller parameters
   auto getParam = parameters_handler_->getParamGetter(name_);
-  getParam(visualize_, "visualize", false);
-
-  getParam(publish_optimal_trajectory_, "publish_optimal_trajectory", false);
 
   // Configure composed objects
   optimizer_.initialize(parent_, name_, costmap_ros_, tf_buffer_, parameters_handler_.get());
   trajectory_visualizer_.on_configure(
     parent_, name_,
     costmap_ros_->getGlobalFrameID(), parameters_handler_.get());
-
-  if (publish_optimal_trajectory_) {
-    opt_traj_pub_ = node->create_publisher<nav2_msgs::msg::Trajectory>(
-      "~/optimal_trajectory");
-  }
 
   RCLCPP_INFO(logger_, "Configured MPPI Controller: %s", name_.c_str());
 }
@@ -59,7 +51,6 @@ void MPPIController::cleanup()
   optimizer_.shutdown();
   trajectory_visualizer_.on_cleanup();
   parameters_handler_.reset();
-  opt_traj_pub_.reset();
   RCLCPP_INFO(logger_, "Cleaned up MPPI Controller: %s", name_.c_str());
 }
 
@@ -68,18 +59,12 @@ void MPPIController::activate()
   auto node = parent_.lock();
   trajectory_visualizer_.on_activate();
   parameters_handler_->start();
-  if (opt_traj_pub_) {
-    opt_traj_pub_->on_activate();
-  }
   RCLCPP_INFO(logger_, "Activated MPPI Controller: %s", name_.c_str());
 }
 
 void MPPIController::deactivate()
 {
   trajectory_visualizer_.on_deactivate();
-  if (opt_traj_pub_) {
-    opt_traj_pub_->on_deactivate();
-  }
   RCLCPP_INFO(logger_, "Deactivated MPPI Controller: %s", name_.c_str());
 }
 
@@ -95,9 +80,9 @@ geometry_msgs::msg::TwistStamped MPPIController::computeVelocityCommands(
   const nav_msgs::msg::Path & transformed_global_plan,
   const geometry_msgs::msg::PoseStamped & global_goal)
 {
-#ifdef BENCHMARK_TESTING
+  #ifdef BENCHMARK_TESTING
   auto start = std::chrono::system_clock::now();
-#endif
+  #endif
 
   std::lock_guard<std::mutex> param_lock(*parameters_handler_->getLock());
 
@@ -108,39 +93,25 @@ geometry_msgs::msg::TwistStamped MPPIController::computeVelocityCommands(
     optimizer_.evalControl(robot_pose, robot_speed, transformed_global_plan, global_goal.pose,
       goal_checker);
 
-#ifdef BENCHMARK_TESTING
+
+  #ifdef BENCHMARK_TESTING
   auto end = std::chrono::system_clock::now();
   auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
   RCLCPP_INFO(logger_, "Control loop execution time: %ld [ms]", duration);
-#endif
+  #endif
 
-  if (publish_optimal_trajectory_ && opt_traj_pub_ && opt_traj_pub_->get_subscription_count() > 0) {
-    std_msgs::msg::Header trajectory_header;
-    trajectory_header.stamp = cmd.header.stamp;
-    trajectory_header.frame_id = costmap_ros_->getGlobalFrameID();
-
-    auto trajectory_msg = utils::toTrajectoryMsg(
-      optimal_trajectory,
-      optimizer_.getOptimalControlSequence(),
-      optimizer_.getSettings().model_dt,
-      trajectory_header);
-    opt_traj_pub_->publish(std::move(trajectory_msg));
-  }
-
-  if (visualize_) {
-    visualize(cmd.header.stamp, optimal_trajectory);
-  }
+  trajectory_visualizer_.visualize(
+    std::move(transformed_plan),
+    optimal_trajectory,
+    optimizer_.getOptimalControlSequence(),
+    optimizer_.getSettings().model_dt,
+    cmd.header.stamp,
+    costmap_ros_,
+    optimizer_.getGeneratedTrajectories(),
+    optimizer_.getCosts(),
+    optimizer_.getCriticCosts());
 
   return cmd;
-}
-
-void MPPIController::visualize(
-  const builtin_interfaces::msg::Time & cmd_stamp,
-  const Eigen::ArrayXXf & optimal_trajectory)
-{
-  trajectory_visualizer_.add(optimizer_.getGeneratedTrajectories(), "Candidate Trajectories");
-  trajectory_visualizer_.add(optimal_trajectory, "Optimal Trajectory", cmd_stamp);
-  trajectory_visualizer_.visualize();
 }
 
 void MPPIController::newPathReceived(const nav_msgs::msg::Path & /*raw_global_path*/)

--- a/nav2_mppi_controller/src/controller.cpp
+++ b/nav2_mppi_controller/src/controller.cpp
@@ -101,7 +101,6 @@ geometry_msgs::msg::TwistStamped MPPIController::computeVelocityCommands(
   #endif
 
   trajectory_visualizer_.visualize(
-    std::move(transformed_plan),
     optimal_trajectory,
     optimizer_.getOptimalControlSequence(),
     optimizer_.getSettings().model_dt,

--- a/nav2_mppi_controller/src/critic_manager.cpp
+++ b/nav2_mppi_controller/src/critic_manager.cpp
@@ -37,7 +37,12 @@ void CriticManager::getParams()
   auto node = parent_.lock();
   auto getParam = parameters_handler_->getParamGetter(name_);
   getParam(critic_names_, "critics", std::vector<std::string>{}, ParameterType::Static);
-  getParam(publish_critics_stats_, "publish_critics_stats", false, ParameterType::Static);
+
+  // Read visualization parameters from Visualization namespace
+  auto getVisualizerParam = parameters_handler_->getParamGetter(name_ + ".Visualization");
+  getVisualizerParam(publish_critics_stats_, "publish_critics_stats", false, ParameterType::Static);
+  getVisualizerParam(visualize_per_critic_costs_, "publish_trajectories_with_individual_cost",
+      false, ParameterType::Static);
 }
 
 void CriticManager::loadCritics()
@@ -83,6 +88,15 @@ void CriticManager::evalTrajectoriesScores(
     stats_msg->costs_sum.reserve(critics_.size());
   }
 
+  // Initialize per-critic costs tracking only if requested
+  if (visualize_per_critic_costs_) {
+    if (!data.individual_critics_cost) {
+      data.individual_critics_cost = std::vector<std::pair<std::string, Eigen::ArrayXf>>();
+    }
+    data.individual_critics_cost->clear();
+    data.individual_critics_cost->reserve(critics_.size());
+  }
+
   for (size_t i = 0; i < critics_.size(); ++i) {
     if (data.fail_flag) {
       break;
@@ -90,21 +104,29 @@ void CriticManager::evalTrajectoriesScores(
 
     // Store costs before critic evaluation
     Eigen::ArrayXf costs_before;
-    if (publish_critics_stats_) {
+    if (visualize_per_critic_costs_ || publish_critics_stats_) {
       costs_before = data.costs;
     }
 
     critics_[i]->score(data);
 
-    // Calculate statistics if publishing is enabled
-    if (publish_critics_stats_) {
-      stats_msg->critics.push_back(critic_names_[i]);
-
-      // Calculate sum of costs added by this individual critic
+    // Calculate cost contribution from this critic
+    if (visualize_per_critic_costs_ || publish_critics_stats_) {
       Eigen::ArrayXf cost_diff = data.costs - costs_before;
-      float costs_sum = cost_diff.sum();
-      stats_msg->costs_sum.push_back(costs_sum);
-      stats_msg->changed.push_back(costs_sum != 0.0f);
+
+      if (visualize_per_critic_costs_) {
+        data.individual_critics_cost->emplace_back(critic_names_[i], cost_diff);
+      }
+
+      // Calculate statistics if publishing is enabled
+      if (publish_critics_stats_) {
+        stats_msg->critics.push_back(critic_names_[i]);
+
+        // Calculate sum of costs added by this individual critic
+        float costs_sum = cost_diff.sum();
+        stats_msg->costs_sum.push_back(costs_sum);
+        stats_msg->changed.push_back(costs_sum != 0.0f);
+      }
     }
   }
 

--- a/nav2_mppi_controller/src/critic_manager.cpp
+++ b/nav2_mppi_controller/src/critic_manager.cpp
@@ -40,9 +40,9 @@ void CriticManager::getParams()
 
   // Read visualization parameters from Visualization namespace
   auto getVisualizerParam = parameters_handler_->getParamGetter(name_ + ".Visualization");
-  getVisualizerParam(publish_critics_stats_, "publish_critics_stats", false, ParameterType::Static);
+  getVisualizerParam(publish_critics_stats_, "publish_critics_stats", false, ParameterType::Dynamic);
   getVisualizerParam(visualize_per_critic_costs_, "publish_trajectories_with_individual_cost",
-      false, ParameterType::Static);
+      false, ParameterType::Dynamic);
 }
 
 void CriticManager::loadCritics()

--- a/nav2_mppi_controller/src/critics/path_align_critic.cpp
+++ b/nav2_mppi_controller/src/critics/path_align_critic.cpp
@@ -30,6 +30,16 @@ void PathAlignCritic::initialize()
     threshold_to_consider_,
     "threshold_to_consider", 0.5f);
   getParam(use_path_orientations_, "use_path_orientations", false);
+  getParam(visualize_furthest_point_, "visualize_furthest_point", false);
+
+  if (visualize_furthest_point_) {
+    auto node = parent_.lock();
+    if (node) {
+      furthest_point_pub_ = node->create_publisher<geometry_msgs::msg::PoseStamped>(
+        "PathAlignCritic/furthest_reached_path_point", 1);
+      furthest_point_pub_->on_activate();
+    }
+  }
 
   RCLCPP_INFO(
     logger_,
@@ -48,6 +58,23 @@ void PathAlignCritic::score(CriticData & data)
   // Up to furthest only, closest path point is always 0 from path handler
   const size_t path_segments_count = *data.furthest_reached_path_point;
   float path_segments_flt = static_cast<float>(path_segments_count);
+
+  // Visualize target pose if enabled
+  if (visualize_furthest_point_ && path_segments_count > 0 &&
+    furthest_point_pub_->get_subscription_count() > 0)
+  {
+    auto furthest_point = std::make_unique<geometry_msgs::msg::PoseStamped>();
+    furthest_point->header.frame_id = costmap_ros_->getGlobalFrameID();
+    furthest_point->header.stamp = clock_->now();
+    furthest_point->pose.position.x = data.path.x(path_segments_count);
+    furthest_point->pose.position.y = data.path.y(path_segments_count);
+    furthest_point->pose.position.z = 0.0;
+    tf2::Quaternion quat;
+    quat.setRPY(0.0, 0.0, data.path.yaws(path_segments_count));
+    furthest_point->pose.orientation = tf2::toMsg(quat);
+    furthest_point_pub_->publish(std::move(furthest_point));
+  }
+
   if (path_segments_count < offset_from_furthest_) {
     return;
   }

--- a/nav2_mppi_controller/src/critics/path_align_critic.cpp
+++ b/nav2_mppi_controller/src/critics/path_align_critic.cpp
@@ -36,7 +36,7 @@ void PathAlignCritic::initialize()
     auto node = parent_.lock();
     if (node) {
       furthest_point_pub_ = node->create_publisher<geometry_msgs::msg::PoseStamped>(
-        "PathAlignCritic/furthest_reached_path_point", 1);
+          "/critics/PathAlignCritic/furthest_reached_path_point", 1);
       furthest_point_pub_->on_activate();
     }
   }

--- a/nav2_mppi_controller/src/critics/path_angle_critic.cpp
+++ b/nav2_mppi_controller/src/critics/path_angle_critic.cpp
@@ -58,7 +58,7 @@ void PathAngleCritic::initialize()
     auto node = parent_.lock();
     if (node) {
       furthest_point_pub_ = node->create_publisher<geometry_msgs::msg::PoseStamped>(
-      "PathAngleCritic/furthest_reached_path_point", 1);
+          "/critics/PathAngleCritic/furthest_reached_path_point", 1);
       furthest_point_pub_->on_activate();
     }
   }

--- a/nav2_mppi_controller/src/critics/path_follow_critic.cpp
+++ b/nav2_mppi_controller/src/critics/path_follow_critic.cpp
@@ -35,7 +35,7 @@ void PathFollowCritic::initialize()
     auto node = parent_.lock();
     if (node) {
       furthest_point_pub_ = node->create_publisher<geometry_msgs::msg::PoseStamped>(
-        "PathFollowCritic/furthest_reached_path_point", 1);
+          "/critics/PathFollowCritic/furthest_reached_path_point", 1);
       furthest_point_pub_->on_activate();
     }
   }

--- a/nav2_mppi_controller/src/trajectory_visualizer.cpp
+++ b/nav2_mppi_controller/src/trajectory_visualizer.cpp
@@ -36,17 +36,12 @@ void TrajectoryVisualizer::on_configure(
       false);
   getParam(publish_optimal_footprints_, "publish_optimal_footprints", false);
   getParam(publish_optimal_trajectory_msg_, "publish_optimal_trajectory_msg", false);
-  getParam(publish_transformed_path_, "publish_transformed_path", false);
   getParam(publish_optimal_path_, "publish_optimal_path", false);
   getParam(footprint_downsample_factor_, "footprint_downsample_factor", 3);
 
   if (publish_trajectories_with_total_cost_ || publish_trajectories_with_individual_cost_) {
     trajectories_publisher_ =
       node->create_publisher<visualization_msgs::msg::MarkerArray>("~/candidate_trajectories");
-  }
-  if (publish_transformed_path_) {
-    transformed_path_pub_ = node->create_publisher<nav_msgs::msg::Path>(
-      "~/transformed_global_plan");
   }
   if (publish_optimal_path_) {
     optimal_path_pub_ = node->create_publisher<nav_msgs::msg::Path>("~/optimal_path");
@@ -76,9 +71,6 @@ void TrajectoryVisualizer::on_activate()
   if (trajectories_publisher_) {
     trajectories_publisher_->on_activate();
   }
-  if (transformed_path_pub_) {
-    transformed_path_pub_->on_activate();
-  }
   if (optimal_path_pub_) {
     optimal_path_pub_->on_activate();
   }
@@ -94,9 +86,6 @@ void TrajectoryVisualizer::on_deactivate()
 {
   if (trajectories_publisher_) {
     trajectories_publisher_->on_deactivate();
-  }
-  if (transformed_path_pub_) {
-    transformed_path_pub_->on_deactivate();
   }
   if (optimal_path_pub_) {
     optimal_path_pub_->on_deactivate();
@@ -294,7 +283,6 @@ void TrajectoryVisualizer::reset()
 }
 
 void TrajectoryVisualizer::visualize(
-  nav_msgs::msg::Path plan,
   const Eigen::ArrayXXf & optimal_trajectory,
   const models::ControlSequence & control_sequence,
   float model_dt,
@@ -362,7 +350,7 @@ void TrajectoryVisualizer::visualize(
   reset();
 }
 
-void TrajectoryVisualizer::visualize(nav_msgs::msg::Path plan)
+void TrajectoryVisualizer::visualize()
 {
   // Simplified version for testing that only publishes what's been added
   if (trajectories_publisher_ && trajectories_publisher_->get_subscription_count() > 0) {
@@ -376,11 +364,6 @@ void TrajectoryVisualizer::visualize(nav_msgs::msg::Path plan)
   }
 
   reset();
-
-  if (transformed_path_pub_ && transformed_path_pub_->get_subscription_count() > 0) {
-    auto plan_ptr = std::make_unique<nav_msgs::msg::Path>(plan);
-    transformed_path_pub_->publish(std::move(plan_ptr));
-  }
 }
 
 visualization_msgs::msg::MarkerArray TrajectoryVisualizer::createFootprintMarkers(

--- a/nav2_mppi_controller/src/trajectory_visualizer.cpp
+++ b/nav2_mppi_controller/src/trajectory_visualizer.cpp
@@ -39,21 +39,13 @@ void TrajectoryVisualizer::on_configure(
   getParam(publish_optimal_path_, "publish_optimal_path", false);
   getParam(footprint_downsample_factor_, "footprint_downsample_factor", 3);
 
-  if (publish_trajectories_with_total_cost_ || publish_trajectories_with_individual_cost_) {
-    trajectories_publisher_ =
-      node->create_publisher<visualization_msgs::msg::MarkerArray>("~/candidate_trajectories");
-  }
-  if (publish_optimal_path_) {
-    optimal_path_pub_ = node->create_publisher<nav_msgs::msg::Path>("~/optimal_path");
-  }
-  if (publish_optimal_footprints_) {
-    optimal_footprints_pub_ = node->create_publisher<visualization_msgs::msg::MarkerArray>(
-      "~/optimal_footprints");
-  }
-  if (publish_optimal_trajectory_msg_) {
-    optimal_trajectory_msg_pub_ = node->create_publisher<nav2_msgs::msg::Trajectory>(
-      "~/optimal_trajectory");
-  }
+  trajectories_publisher_ =
+    node->create_publisher<visualization_msgs::msg::MarkerArray>("~/candidate_trajectories");
+  optimal_path_pub_ = node->create_publisher<nav_msgs::msg::Path>("~/optimal_path");
+  optimal_footprints_pub_ = node->create_publisher<visualization_msgs::msg::MarkerArray>(
+    "~/optimal_footprints");
+  optimal_trajectory_msg_pub_ = node->create_publisher<nav2_msgs::msg::Trajectory>(
+    "~/optimal_trajectory");
 
   reset();
 }
@@ -152,11 +144,6 @@ void TrajectoryVisualizer::add(
   const std::vector<std::pair<std::string, Eigen::ArrayXf>> & individual_critics_cost,
   const builtin_interfaces::msg::Time & cmd_stamp)
 {
-  // Check if we should visualize per-critic costs
-  bool visualize_per_critic = !individual_critics_cost.empty() &&
-    publish_trajectories_with_individual_cost_ &&
-    trajectories_publisher_ && trajectories_publisher_->get_subscription_count() > 0;
-
   size_t n_rows = trajectories.x.rows();
   points_->markers.reserve(n_rows / trajectory_step_);
 
@@ -164,6 +151,10 @@ void TrajectoryVisualizer::add(
   if (publish_trajectories_with_total_cost_) {
     createTrajectoryMarkers(trajectories, total_costs, "Total Costs", cmd_stamp);
   }
+
+  // Check if we should visualize per-critic costs
+  bool visualize_per_critic = !individual_critics_cost.empty() &&
+    publish_trajectories_with_individual_cost_;
 
   // Visualize each critic's contribution if requested
   if (visualize_per_critic) {
@@ -297,24 +288,17 @@ void TrajectoryVisualizer::visualize(
   header.stamp = stamp;
   header.frame_id = costmap_ros->getGlobalFrameID();
 
-  // Visualize trajectories with total costs
-  if (publish_trajectories_with_total_cost_ ||
-    (!publish_trajectories_with_individual_cost_ || critic_costs.empty()))
-  {
-    add(candidate_trajectories, costs, {}, stamp);
-  }
-
-  // Visualize trajectories with individual critic costs
-  if (publish_trajectories_with_individual_cost_ && !critic_costs.empty()) {
-    add(candidate_trajectories, costs, critic_costs, stamp);
-  }
-
   // Add optimal trajectory to populate optimal_path_
   if (publish_optimal_path_ && optimal_trajectory.rows() > 0) {
     add(optimal_trajectory, "Optimal Trajectory", stamp);
   }
 
-  // Publish trajectories
+  if (publish_trajectories_with_total_cost_ || publish_trajectories_with_individual_cost_)
+  {
+    add(candidate_trajectories, costs, critic_costs, stamp);
+  }
+
+    // Publish trajectories
   if (trajectories_publisher_ && trajectories_publisher_->get_subscription_count() > 0) {
     trajectories_publisher_->publish(std::move(points_));
   }

--- a/nav2_mppi_controller/src/trajectory_visualizer.cpp
+++ b/nav2_mppi_controller/src/trajectory_visualizer.cpp
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #include <memory>
+#include <vector>
+#include <algorithm>
 #include "nav2_mppi_controller/tools/trajectory_visualizer.hpp"
 
 namespace mppi
@@ -25,15 +27,38 @@ void TrajectoryVisualizer::on_configure(
   auto node = parent.lock();
   logger_ = node->get_logger();
   frame_id_ = frame_id;
-  trajectories_publisher_ =
-    node->create_publisher<visualization_msgs::msg::MarkerArray>("~/candidate_trajectories");
-  optimal_path_pub_ = node->create_publisher<nav_msgs::msg::Path>("~/optimal_path");
   parameters_handler_ = parameters_handler;
-
-  auto getParam = parameters_handler->getParamGetter(name + ".TrajectoryVisualizer");
-
+  auto getParam = parameters_handler->getParamGetter(name + ".Visualization");
   getParam(trajectory_step_, "trajectory_step", 5);
   getParam(time_step_, "time_step", 3);
+  getParam(publish_trajectories_with_total_cost_, "publish_trajectories_with_total_cost", false);
+  getParam(publish_trajectories_with_individual_cost_, "publish_trajectories_with_individual_cost",
+      false);
+  getParam(publish_optimal_footprints_, "publish_optimal_footprints", false);
+  getParam(publish_optimal_trajectory_msg_, "publish_optimal_trajectory_msg", false);
+  getParam(publish_transformed_path_, "publish_transformed_path", false);
+  getParam(publish_optimal_path_, "publish_optimal_path", false);
+  getParam(footprint_downsample_factor_, "footprint_downsample_factor", 3);
+
+  if (publish_trajectories_with_total_cost_ || publish_trajectories_with_individual_cost_) {
+    trajectories_publisher_ =
+      node->create_publisher<visualization_msgs::msg::MarkerArray>("~/candidate_trajectories");
+  }
+  if (publish_transformed_path_) {
+    transformed_path_pub_ = node->create_publisher<nav_msgs::msg::Path>(
+      "~/transformed_global_plan");
+  }
+  if (publish_optimal_path_) {
+    optimal_path_pub_ = node->create_publisher<nav_msgs::msg::Path>("~/optimal_path");
+  }
+  if (publish_optimal_footprints_) {
+    optimal_footprints_pub_ = node->create_publisher<visualization_msgs::msg::MarkerArray>(
+      "~/optimal_footprints");
+  }
+  if (publish_optimal_trajectory_msg_) {
+    optimal_trajectory_msg_pub_ = node->create_publisher<nav2_msgs::msg::Trajectory>(
+      "~/optimal_trajectory");
+  }
 
   reset();
 }
@@ -42,18 +67,46 @@ void TrajectoryVisualizer::on_cleanup()
 {
   trajectories_publisher_.reset();
   optimal_path_pub_.reset();
+  optimal_footprints_pub_.reset();
+  optimal_trajectory_msg_pub_.reset();
 }
 
 void TrajectoryVisualizer::on_activate()
 {
-  trajectories_publisher_->on_activate();
-  optimal_path_pub_->on_activate();
+  if (trajectories_publisher_) {
+    trajectories_publisher_->on_activate();
+  }
+  if (transformed_path_pub_) {
+    transformed_path_pub_->on_activate();
+  }
+  if (optimal_path_pub_) {
+    optimal_path_pub_->on_activate();
+  }
+  if (optimal_footprints_pub_) {
+    optimal_footprints_pub_->on_activate();
+  }
+  if (optimal_trajectory_msg_pub_) {
+    optimal_trajectory_msg_pub_->on_activate();
+  }
 }
 
 void TrajectoryVisualizer::on_deactivate()
 {
-  trajectories_publisher_->on_deactivate();
-  optimal_path_pub_->on_deactivate();
+  if (trajectories_publisher_) {
+    trajectories_publisher_->on_deactivate();
+  }
+  if (transformed_path_pub_) {
+    transformed_path_pub_->on_deactivate();
+  }
+  if (optimal_path_pub_) {
+    optimal_path_pub_->on_deactivate();
+  }
+  if (optimal_footprints_pub_) {
+    optimal_footprints_pub_->on_deactivate();
+  }
+  if (optimal_trajectory_msg_pub_) {
+    optimal_trajectory_msg_pub_->on_deactivate();
+  }
 }
 
 void TrajectoryVisualizer::add(
@@ -105,7 +158,37 @@ void TrajectoryVisualizer::add(
 }
 
 void TrajectoryVisualizer::add(
-  const models::Trajectories & trajectories, const std::string & marker_namespace)
+  const models::Trajectories & trajectories,
+  const Eigen::ArrayXf & total_costs,
+  const std::vector<std::pair<std::string, Eigen::ArrayXf>> & individual_critics_cost,
+  const builtin_interfaces::msg::Time & cmd_stamp)
+{
+  // Check if we should visualize per-critic costs
+  bool visualize_per_critic = !individual_critics_cost.empty() &&
+    publish_trajectories_with_individual_cost_ &&
+    trajectories_publisher_ && trajectories_publisher_->get_subscription_count() > 0;
+
+  size_t n_rows = trajectories.x.rows();
+  points_->markers.reserve(n_rows / trajectory_step_);
+
+  // Visualize total costs if requested
+  if (publish_trajectories_with_total_cost_) {
+    createTrajectoryMarkers(trajectories, total_costs, "Total Costs", cmd_stamp);
+  }
+
+  // Visualize each critic's contribution if requested
+  if (visualize_per_critic) {
+    for (const auto & [critic_name, costs] : individual_critics_cost) {
+      createTrajectoryMarkers(trajectories, costs, critic_name, cmd_stamp);
+    }
+  }
+}
+
+void TrajectoryVisualizer::createTrajectoryMarkers(
+  const models::Trajectories & trajectories,
+  const Eigen::ArrayXf & costs,
+  const std::string & ns,
+  const builtin_interfaces::msg::Time & cmd_stamp)
 {
   if (trajectories_publisher_->get_subscription_count() == 0) {
     return;
@@ -113,8 +196,22 @@ void TrajectoryVisualizer::add(
 
   size_t n_rows = trajectories.x.rows();
   size_t n_cols = trajectories.x.cols();
-  const float shape_1 = static_cast<float>(n_cols);
-  points_->markers.reserve(floor(n_rows / trajectory_step_) * floor(n_cols * time_step_));
+
+  // Find min/max cost for normalization
+  float min_cost = std::numeric_limits<float>::max();
+  float max_cost = std::numeric_limits<float>::lowest();
+
+  for (Eigen::Index i = 0; i < costs.size(); ++i) {
+    min_cost = std::min(min_cost, costs(i));
+    max_cost = std::max(max_cost, costs(i));
+  }
+
+  float cost_range = max_cost - min_cost;
+
+  // Avoid division by zero
+  if (cost_range < 1e-6f) {
+    cost_range = 1.0f;
+  }
 
   std::vector<std::pair<size_t, float>> sorted_costs;
   sorted_costs.reserve(std::ceil(n_rows / trajectory_step_));
@@ -133,19 +230,59 @@ void TrajectoryVisualizer::add(
   }
 
   for (size_t i = 0; i < n_rows; i += trajectory_step_) {
-    for (size_t j = 0; j < n_cols; j += time_step_) {
-      const float j_flt = static_cast<float>(j);
-      float blue_component = 1.0f - j_flt / shape_1;
-      float green_component = j_flt / shape_1;
+    float red_component, green_component, blue_component;
 
-      auto pose = utils::createPose(trajectories.x(i, j), trajectories.y(i, j), 0.03);
-      auto scale = utils::createScale(0.03, 0.03, 0.03);
-      auto color = utils::createColor(cost_color_map[i], green_component, blue_component, 1);
-      auto marker = utils::createMarker(
-        marker_id_++, pose, scale, color, frame_id_, marker_namespace);
+    // Check if cost is zero (no contribution from this critic)
+    bool zero_cost = std::abs(costs(i)) < 1e-6f;
 
-      points_->markers.push_back(marker);
+    if (zero_cost) {
+      // Gray color for zero cost (no contribution)
+      red_component = 0.5f;
+      green_component = 0.5f;
+      blue_component = 0.5f;
+    } else {
+      // Normal gradient for trajectories
+      float normalized_cost = (costs(i) - min_cost) / cost_range;
+      normalized_cost = std::clamp(normalized_cost, 0.0f, 1.0f);
+
+      // Color scheme: Green (low cost) -> Yellow -> Red (high cost)
+      blue_component = 0.0f;
+      if (normalized_cost < 0.5f) {
+        // Green to Yellow (0.0 - 0.5)
+        red_component = normalized_cost * 2.0f;
+        green_component = 1.0f;
+      } else {
+        // Yellow to Red (0.5 - 1.0)
+        red_component = 1.0f;
+        green_component = 2.0f * (1.0f - normalized_cost);
+      }
     }
+
+    // Create line strip marker for this trajectory
+    visualization_msgs::msg::Marker marker;
+    marker.header.frame_id = frame_id_;
+    marker.header.stamp = cmd_stamp;
+    marker.ns = ns;
+    marker.id = marker_id_++;
+    marker.type = visualization_msgs::msg::Marker::LINE_STRIP;
+    marker.action = visualization_msgs::msg::Marker::ADD;
+    marker.pose.orientation.w = 1.0;
+    marker.scale.x = 0.01;  // Line width
+    marker.color.r = red_component;
+    marker.color.g = green_component;
+    marker.color.b = blue_component;
+    marker.color.a = 1.0;
+
+    // Add all points in this trajectory to the line strip
+    for (size_t j = 0; j < n_cols; j += time_step_) {
+      geometry_msgs::msg::Point point;
+      point.x = trajectories.x(i, j);
+      point.y = trajectories.y(i, j);
+      point.z = 0.0f;
+      marker.points.push_back(point);
+    }
+
+    points_->markers.push_back(marker);
   }
 }
 
@@ -156,17 +293,161 @@ void TrajectoryVisualizer::reset()
   optimal_path_ = std::make_unique<nav_msgs::msg::Path>();
 }
 
-void TrajectoryVisualizer::visualize()
+void TrajectoryVisualizer::visualize(
+  nav_msgs::msg::Path plan,
+  const Eigen::ArrayXXf & optimal_trajectory,
+  const models::ControlSequence & control_sequence,
+  float model_dt,
+  const builtin_interfaces::msg::Time & stamp,
+  std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros,
+  const models::Trajectories & candidate_trajectories,
+  const Eigen::ArrayXf & costs,
+  const std::vector<std::pair<std::string, Eigen::ArrayXf>> & critic_costs)
 {
-  if (trajectories_publisher_->get_subscription_count() > 0) {
+  // Create header with frame from costmap
+  std_msgs::msg::Header header;
+  header.stamp = stamp;
+  header.frame_id = costmap_ros->getGlobalFrameID();
+
+  // Visualize trajectories with total costs
+  if (publish_trajectories_with_total_cost_ ||
+    (!publish_trajectories_with_individual_cost_ || critic_costs.empty()))
+  {
+    add(candidate_trajectories, costs, {}, stamp);
+  }
+
+  // Visualize trajectories with individual critic costs
+  if (publish_trajectories_with_individual_cost_ && !critic_costs.empty()) {
+    add(candidate_trajectories, costs, critic_costs, stamp);
+  }
+
+  // Add optimal trajectory to populate optimal_path_
+  if (publish_optimal_path_ && optimal_trajectory.rows() > 0) {
+    add(optimal_trajectory, "Optimal Trajectory", stamp);
+  }
+
+  // Publish trajectories
+  if (trajectories_publisher_ && trajectories_publisher_->get_subscription_count() > 0) {
     trajectories_publisher_->publish(std::move(points_));
   }
 
-  if (optimal_path_pub_->get_subscription_count() > 0) {
+  // Publish optimal path if enabled
+  if (publish_optimal_path_ && optimal_path_pub_ &&
+    optimal_path_pub_->get_subscription_count() > 0)
+  {
+    optimal_path_pub_->publish(std::move(optimal_path_));
+  }
+
+  // Publish optimal footprints if enabled
+  if (publish_optimal_footprints_ && optimal_footprints_pub_ &&
+    optimal_footprints_pub_->get_subscription_count() > 0 &&
+    costmap_ros != nullptr && optimal_trajectory.rows() > 0)
+  {
+    auto footprints_msg = createFootprintMarkers(optimal_trajectory, header, costmap_ros);
+    optimal_footprints_pub_->publish(std::move(footprints_msg));
+  }
+
+  // Publish optimal trajectory message if enabled
+  if (publish_optimal_trajectory_msg_ && optimal_trajectory_msg_pub_ &&
+    optimal_trajectory_msg_pub_->get_subscription_count() > 0)
+  {
+    auto trajectory_msg = utils::toTrajectoryMsg(
+      optimal_trajectory,
+      control_sequence,
+      model_dt,
+      header);
+    optimal_trajectory_msg_pub_->publish(std::move(trajectory_msg));
+  }
+
+  reset();
+}
+
+void TrajectoryVisualizer::visualize(nav_msgs::msg::Path plan)
+{
+  // Simplified version for testing that only publishes what's been added
+  if (trajectories_publisher_ && trajectories_publisher_->get_subscription_count() > 0) {
+    trajectories_publisher_->publish(std::move(points_));
+  }
+
+  if (publish_optimal_path_ && optimal_path_pub_ &&
+    optimal_path_pub_->get_subscription_count() > 0)
+  {
     optimal_path_pub_->publish(std::move(optimal_path_));
   }
 
   reset();
+
+  if (transformed_path_pub_ && transformed_path_pub_->get_subscription_count() > 0) {
+    auto plan_ptr = std::make_unique<nav_msgs::msg::Path>(plan);
+    transformed_path_pub_->publish(std::move(plan_ptr));
+  }
+}
+
+visualization_msgs::msg::MarkerArray TrajectoryVisualizer::createFootprintMarkers(
+  const Eigen::ArrayXXf & trajectory,
+  const std_msgs::msg::Header & header,
+  std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros)
+{
+  visualization_msgs::msg::MarkerArray marker_array;
+  if (trajectory.rows() == 0) {
+    return marker_array;
+  }
+
+  // Get robot footprint
+  std::vector<geometry_msgs::msg::Point> robot_footprint =
+    costmap_ros->getRobotFootprint();
+
+  // Skip if footprint is empty or very small
+  if (robot_footprint.size() < 3) {
+    return marker_array;
+  }
+
+  // Create header for markers
+  std_msgs::msg::Header costmap_header;
+  costmap_header.frame_id = costmap_ros->getGlobalFrameID();
+  costmap_header.stamp = header.stamp;
+
+  int marker_id = 0;
+  for (int i = 0; i < trajectory.rows(); i += footprint_downsample_factor_) {
+    double x = trajectory(i, 0);
+    double y = trajectory(i, 1);
+    double theta = trajectory(i, 2);
+
+    // Create oriented footprint
+    geometry_msgs::msg::PolygonStamped oriented_footprint;
+    oriented_footprint.header = costmap_header;
+    nav2_costmap_2d::transformFootprint(x, y, theta, robot_footprint, oriented_footprint);
+    // Create marker for this footprint
+    visualization_msgs::msg::Marker marker;
+    marker.header = costmap_header;
+    marker.ns = "optimal_footprints";
+    marker.id = marker_id++;
+    marker.type = visualization_msgs::msg::Marker::LINE_STRIP;
+    marker.action = visualization_msgs::msg::Marker::ADD;
+    marker.pose.orientation.w = 1.0;
+    // Set marker scale and color
+    marker.scale.x = 0.02;  // Line width
+    marker.color.r = 0.0;
+    marker.color.g = 1.0;
+    marker.color.b = 0.0;
+    marker.color.a = 0.8;
+    // Add footprint points to marker
+    for (const auto & point : oriented_footprint.polygon.points) {
+      geometry_msgs::msg::Point p;
+      p.x = point.x;
+      p.y = point.y;
+      p.z = 0.0;
+      marker.points.push_back(p);
+    }
+    // Close the polygon by adding the first point again
+    if (!marker.points.empty()) {
+      marker.points.push_back(marker.points[0]);
+    }
+
+    marker_array.markers.push_back(marker);
+  }
+
+  return marker_array;
 }
 
 }  // namespace mppi

--- a/nav2_mppi_controller/src/trajectory_visualizer.cpp
+++ b/nav2_mppi_controller/src/trajectory_visualizer.cpp
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "nav2_mppi_controller/tools/trajectory_visualizer.hpp"
+
+#include <algorithm>
 #include <memory>
 #include <vector>
-#include <algorithm>
-#include "nav2_mppi_controller/tools/trajectory_visualizer.hpp"
 
 namespace mppi
 {

--- a/nav2_mppi_controller/test/critic_manager_test.cpp
+++ b/nav2_mppi_controller/test/critic_manager_test.cpp
@@ -114,7 +114,8 @@ TEST(CriticManagerTests, BasicCriticOperations)
   Eigen::ArrayXf costs;
   float model_dt = 0.1;
   CriticData data =
-  {state, generated_trajectories, path, goal, costs, model_dt, false, nullptr, nullptr,
+  {state, generated_trajectories, path, goal, costs, std::nullopt, model_dt, false, nullptr,
+    nullptr,
     std::nullopt, std::nullopt};
 
   data.fail_flag = true;

--- a/nav2_mppi_controller/test/critics_tests.cpp
+++ b/nav2_mppi_controller/test/critics_tests.cpp
@@ -289,7 +289,7 @@ TEST(CriticTests, GoalAngleCriticSymmetric)
   Eigen::ArrayXf costs = Eigen::ArrayXf::Zero(1000);
   float model_dt = 0.1;
   CriticData data =
-  {state, generated_trajectories, path, goal, costs, model_dt,
+  {state, generated_trajectories, path, goal, costs, std::nullopt, model_dt,
     false, nullptr, nullptr, std::nullopt, std::nullopt};
   data.motion_model = std::make_shared<DiffDriveMotionModel>();
 

--- a/nav2_mppi_controller/test/critics_tests.cpp
+++ b/nav2_mppi_controller/test/critics_tests.cpp
@@ -79,7 +79,7 @@ TEST(CriticTests, ConstraintsCritic)
   Eigen::ArrayXf costs = Eigen::ArrayXf::Zero(1000);
   float model_dt = 0.1;
   CriticData data =
-  {state, generated_trajectories, path, goal, costs, model_dt,
+  {state, generated_trajectories, path, goal, costs, std::nullopt, model_dt,
     false, nullptr, nullptr, std::nullopt, std::nullopt};
   data.motion_model = std::make_shared<DiffDriveMotionModel>();
 
@@ -227,7 +227,7 @@ TEST(CriticTests, GoalAngleCritic)
   Eigen::ArrayXf costs = Eigen::ArrayXf::Zero(1000);
   float model_dt = 0.1;
   CriticData data =
-  {state, generated_trajectories, path, goal, costs, model_dt,
+  {state, generated_trajectories, path, goal, costs, std::nullopt, model_dt,
     false, nullptr, nullptr, std::nullopt, std::nullopt};
   data.motion_model = std::make_shared<DiffDriveMotionModel>();
 
@@ -350,7 +350,7 @@ TEST(CriticTests, GoalCritic)
   Eigen::ArrayXf costs = Eigen::ArrayXf::Zero(1000);
   float model_dt = 0.1;
   CriticData data =
-  {state, generated_trajectories, path, goal, costs, model_dt,
+  {state, generated_trajectories, path, goal, costs, std::nullopt, model_dt,
     false, nullptr, nullptr, std::nullopt, std::nullopt};
   data.motion_model = std::make_shared<DiffDriveMotionModel>();
 
@@ -406,7 +406,7 @@ TEST(CriticTests, PathAngleCritic)
   Eigen::ArrayXf costs = Eigen::ArrayXf::Zero(1000);
   float model_dt = 0.1;
   CriticData data =
-  {state, generated_trajectories, path, goal, costs, model_dt,
+  {state, generated_trajectories, path, goal, costs, std::nullopt, model_dt,
     false, nullptr, nullptr, std::nullopt, std::nullopt};
   data.motion_model = std::make_shared<DiffDriveMotionModel>();
   TestGoalChecker goal_checker;  // from utils_tests tolerance of 0.25 positionally
@@ -527,7 +527,7 @@ TEST(CriticTests, PreferForwardCritic)
   Eigen::ArrayXf costs = Eigen::ArrayXf::Zero(1000);
   float model_dt = 0.1;
   CriticData data =
-  {state, generated_trajectories, path, goal, costs, model_dt,
+  {state, generated_trajectories, path, goal, costs, std::nullopt, model_dt,
     false, nullptr, nullptr, std::nullopt, std::nullopt};
   data.motion_model = std::make_shared<DiffDriveMotionModel>();
   TestGoalChecker goal_checker;  // from utils_tests tolerance of 0.25 positionally
@@ -586,7 +586,7 @@ TEST(CriticTests, TwirlingCritic)
   Eigen::ArrayXf costs = Eigen::ArrayXf::Zero(1000);
   float model_dt = 0.1;
   CriticData data =
-  {state, generated_trajectories, path, goal, costs, model_dt,
+  {state, generated_trajectories, path, goal, costs, std::nullopt, model_dt,
     false, nullptr, nullptr, std::nullopt, std::nullopt};
   data.motion_model = std::make_shared<DiffDriveMotionModel>();
   TestGoalChecker goal_checker;  // from utils_tests tolerance of 0.25 positionally
@@ -653,7 +653,7 @@ TEST(CriticTests, PathFollowCritic)
   Eigen::ArrayXf costs = Eigen::ArrayXf::Zero(1000);
   float model_dt = 0.1;
   CriticData data =
-  {state, generated_trajectories, path, goal, costs, model_dt,
+  {state, generated_trajectories, path, goal, costs, std::nullopt, model_dt,
     false, nullptr, nullptr, std::nullopt, std::nullopt};
   data.motion_model = std::make_shared<DiffDriveMotionModel>();
   TestGoalChecker goal_checker;  // from utils_tests tolerance of 0.25 positionally
@@ -707,7 +707,7 @@ TEST(CriticTests, PathAlignCritic)
   Eigen::ArrayXf costs = Eigen::ArrayXf::Zero(1000);
   float model_dt = 0.1;
   CriticData data =
-  {state, generated_trajectories, path, goal, costs, model_dt,
+  {state, generated_trajectories, path, goal, costs, std::nullopt, model_dt,
     false, nullptr, nullptr, std::nullopt, std::nullopt};
   data.motion_model = std::make_shared<DiffDriveMotionModel>();
   TestGoalChecker goal_checker;  // from utils_tests tolerance of 0.25 positionally
@@ -824,7 +824,7 @@ TEST(CriticTests, VelocityDeadbandCritic)
   Eigen::ArrayXf costs = Eigen::ArrayXf::Zero(1000);
   float model_dt = 0.1;
   CriticData data =
-  {state, generated_trajectories, path, goal, costs, model_dt,
+  {state, generated_trajectories, path, goal, costs, std::nullopt, model_dt,
     false, nullptr, nullptr, std::nullopt, std::nullopt};
   data.motion_model = std::make_shared<OmniMotionModel>();
 

--- a/nav2_mppi_controller/test/trajectory_visualizer_tests.cpp
+++ b/nav2_mppi_controller/test/trajectory_visualizer_tests.cpp
@@ -62,7 +62,7 @@ TEST(TrajectoryVisualizerTests, VisPathRepub)
   TrajectoryVisualizer vis;
   vis.on_configure(node, "my_name", "map", parameters_handler.get());
   vis.on_activate();
-  vis.visualize(pub_path);
+  vis.visualize();
 
   executor.spin_some();
   EXPECT_EQ(received_path.poses.size(), 5u);
@@ -173,7 +173,7 @@ TEST(TrajectoryVisualizerTests, VisCandidateTrajectories)
   vis.on_activate();
   vis.add(candidate_trajectories, costs, {}, cmd_stamp);
   nav_msgs::msg::Path bogus_path;
-  vis.visualize(bogus_path);
+  vis.visualize();
 
   executor.spin_some();
   // 200 trajectories / 5 trajectory_step = 40 LINE_STRIP markers

--- a/nav2_mppi_controller/test/trajectory_visualizer_tests.cpp
+++ b/nav2_mppi_controller/test/trajectory_visualizer_tests.cpp
@@ -36,10 +36,48 @@ TEST(TrajectoryVisualizerTests, StateTransition)
   vis.on_cleanup();
 }
 
+TEST(TrajectoryVisualizerTests, VisPathRepub)
+{
+  auto node = std::make_shared<nav2::LifecycleNode>("my_node");
+  std::string name = "test";
+
+  // Set parameter to enable transformed path publishing
+  node->declare_parameter(
+    "my_name.Visualization.publish_transformed_path", rclcpp::ParameterValue(true));
+
+  auto parameters_handler = std::make_unique<ParametersHandler>(node, name);
+
+  nav_msgs::msg::Path received_path;
+  nav_msgs::msg::Path pub_path;
+  pub_path.header.frame_id = "fake_frame";
+  pub_path.poses.resize(5);
+
+  auto my_sub = node->create_subscription<nav_msgs::msg::Path>(
+    "~/transformed_global_plan",
+    [&](const nav_msgs::msg::Path msg) {received_path = msg;});
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node->get_node_base_interface());
+
+  TrajectoryVisualizer vis;
+  vis.on_configure(node, "my_name", "map", parameters_handler.get());
+  vis.on_activate();
+  vis.visualize(pub_path);
+
+  executor.spin_some();
+  EXPECT_EQ(received_path.poses.size(), 5u);
+  EXPECT_EQ(received_path.header.frame_id, "fake_frame");
+}
+
 TEST(TrajectoryVisualizerTests, VisOptimalTrajectory)
 {
   auto node = std::make_shared<nav2::LifecycleNode>("my_node");
   std::string name = "test";
+
+  // Set parameter to enable trajectory publishing
+  node->declare_parameter(
+    "my_name.Visualization.publish_trajectories_with_total_cost", rclcpp::ParameterValue(true));
+
   auto parameters_handler = std::make_unique<ParametersHandler>(node, name);
 
   visualization_msgs::msg::MarkerArray received_msg;
@@ -104,7 +142,16 @@ TEST(TrajectoryVisualizerTests, VisCandidateTrajectories)
 {
   auto node = std::make_shared<nav2::LifecycleNode>("my_node");
   std::string name = "test";
+
+  // Set parameter to enable trajectory publishing
+  node->declare_parameter(
+    "my_name.Visualization.publish_trajectories_with_total_cost", rclcpp::ParameterValue(true));
+
   auto parameters_handler = std::make_unique<ParametersHandler>(node, name);
+
+  builtin_interfaces::msg::Time cmd_stamp;
+  cmd_stamp.sec = 5;
+  cmd_stamp.nanosec = 10;
 
   visualization_msgs::msg::MarkerArray received_msg;
   auto my_sub = node->create_subscription<visualization_msgs::msg::MarkerArray>(
@@ -119,22 +166,32 @@ TEST(TrajectoryVisualizerTests, VisCandidateTrajectories)
   candidate_trajectories.y = Eigen::ArrayXXf::Ones(200, 12);
   candidate_trajectories.yaws = Eigen::ArrayXXf::Ones(200, 12);
 
+  Eigen::ArrayXf costs = Eigen::ArrayXf::Random(200);
+
   TrajectoryVisualizer vis;
   vis.on_configure(node, "my_name", "fkmap", parameters_handler.get());
   vis.on_activate();
-  vis.add(candidate_trajectories, "Candidate Trajectories");
-  vis.visualize();
+  vis.add(candidate_trajectories, costs, {}, cmd_stamp);
+  nav_msgs::msg::Path bogus_path;
+  vis.visualize(bogus_path);
 
   executor.spin_some();
-  // 40 * 4, for 5 trajectory steps + 3 point steps
-  EXPECT_EQ(received_msg.markers.size(), 160u);
+  // 200 trajectories / 5 trajectory_step = 40 LINE_STRIP markers
+  // Each LINE_STRIP contains 12 cols / 3 time_step = 4 points
+  EXPECT_EQ(received_msg.markers.size(), 40u);
 }
 
 TEST(TrajectoryVisualizerTests, VisOptimalPath)
 {
   auto node = std::make_shared<nav2::LifecycleNode>("my_node");
   std::string name = "test";
+
+  // Set parameter to enable optimal path publishing
+  node->declare_parameter(
+    "my_name.Visualization.publish_optimal_path", rclcpp::ParameterValue(true));
+
   auto parameters_handler = std::make_unique<ParametersHandler>(node, name);
+
   builtin_interfaces::msg::Time cmd_stamp;
   cmd_stamp.sec = 5;
   cmd_stamp.nanosec = 10;

--- a/nav2_mppi_controller/test/utils_test.cpp
+++ b/nav2_mppi_controller/test/utils_test.cpp
@@ -182,7 +182,8 @@ TEST(UtilsTests, FurthestAndClosestReachedPoint)
   float model_dt = 0.1;
 
   CriticData data =
-  {state, generated_trajectories, path, goal, costs, model_dt, false, nullptr, nullptr,
+  {state, generated_trajectories, path, goal, costs, std::nullopt, model_dt, false, nullptr,
+    nullptr,
     std::nullopt, std::nullopt};  /// Caution, keep references
 
   // Attempt to set furthest point if notionally set, should not change
@@ -192,7 +193,8 @@ TEST(UtilsTests, FurthestAndClosestReachedPoint)
 
   // Attempt to set if not set already with no other information, should fail
   CriticData data2 =
-  {state, generated_trajectories, path, goal, costs, model_dt, false, nullptr, nullptr,
+  {state, generated_trajectories, path, goal, costs, std::nullopt, model_dt, false, nullptr,
+    nullptr,
     std::nullopt, std::nullopt};  /// Caution, keep references
   setPathFurthestPointIfNotSet(data2);
   EXPECT_EQ(data2.furthest_reached_path_point, 0);
@@ -211,7 +213,8 @@ TEST(UtilsTests, FurthestAndClosestReachedPoint)
   path = toTensor(plan);
 
   CriticData data3 =
-  {state, generated_trajectories, path, goal, costs, model_dt, false, nullptr, nullptr,
+  {state, generated_trajectories, path, goal, costs, std::nullopt, model_dt, false, nullptr,
+    nullptr,
     std::nullopt, std::nullopt};  /// Caution, keep references
   EXPECT_EQ(findPathFurthestReachedPoint(data3), 5);
 }
@@ -227,7 +230,8 @@ TEST(UtilsTests, findPathCosts)
   float model_dt = 0.1;
 
   CriticData data =
-  {state, generated_trajectories, path, goal, costs, model_dt, false, nullptr, nullptr,
+  {state, generated_trajectories, path, goal, costs, std::nullopt, model_dt, false, nullptr,
+    nullptr,
     std::nullopt, std::nullopt};  /// Caution, keep references
 
   // Test not set if already set, should not change
@@ -240,7 +244,8 @@ TEST(UtilsTests, findPathCosts)
   EXPECT_EQ(data.path_pts_valid->size(), 10u);
 
   CriticData data3 =
-  {state, generated_trajectories, path, goal, costs, model_dt, false, nullptr, nullptr,
+  {state, generated_trajectories, path, goal, costs, std::nullopt, model_dt, false, nullptr,
+    nullptr,
     std::nullopt, std::nullopt};  /// Caution, keep references
 
   auto costmap_ros = std::make_shared<nav2_costmap_2d::Costmap2DROS>(


### PR DESCRIPTION
Add MPPI visualization based on https://github.com/ros-navigation/navigation2/pull/5643

Note: This is a cherry-pick of a PR which was stopped mid-progress. It works wel but may not be the cleanest.

Note 2: Recentely, [another vis PR](https://github.com/ros-navigation/navigation2/pull/6036) was merged, but using a slightly different method and missing the visualization of `furthest_reached` point for critics. Considering the current code is ok for us, and the merged PR is missing the most useful feature, I decided to use this version, and reconsider in the next rebase on upstream,