### PR TITLE
PathAlignCritic: Improve occupancy check, Add DirectionChangeCritic

### DIFF
--- a/nav2_mppi_controller/CMakeLists.txt
+++ b/nav2_mppi_controller/CMakeLists.txt
@@ -83,6 +83,7 @@ add_library(mppi_critics SHARED
   src/critics/prefer_forward_critic.cpp
   src/critics/twirling_critic.cpp
   src/critics/velocity_deadband_critic.cpp
+  src/critics/direction_change_critic.cpp
 )
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND APPLE)
     # Apple Clang: use C++20 and optimization, omit -fconcepts

--- a/nav2_mppi_controller/critics.xml
+++ b/nav2_mppi_controller/critics.xml
@@ -45,5 +45,9 @@
       <description>mppi critic for restricting command velocities in deadband range</description>
     </class>
 
+    <class type="mppi::critics::DirectionChangeCritic" base_class_type="mppi::critics::CriticFunction">
+      <description>mppi critic for penalizing changes in driving direction</description>
+    </class>
+
   </library>
 </class_libraries>

--- a/nav2_mppi_controller/include/nav2_mppi_controller/critics/direction_change_critic.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/critics/direction_change_critic.hpp
@@ -36,7 +36,7 @@ public:
   /**
    * @brief Evaluate cost related to changing driving direction
    *
-   * @param costs [out] add goal angle cost values to this tensor
+   * @param costs [out] add cost values to this tensor
    */
   void score(CriticData & data) override;
 
@@ -44,7 +44,6 @@ protected:
   unsigned int power_{0};
   float weight_{0};
   float threshold_to_consider_{0};
-  bool enforce_path_inversion_{false};
 };
 
 }  // namespace mppi::critics

--- a/nav2_mppi_controller/include/nav2_mppi_controller/critics/direction_change_critic.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/critics/direction_change_critic.hpp
@@ -1,0 +1,52 @@
+// Copyright (c) 2024 Enway GmbH, Adi Vardi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NAV2_MPPI_CONTROLLER__CRITICS__DIRECTION_CHANGE_CRITIC_HPP_
+#define NAV2_MPPI_CONTROLLER__CRITICS__DIRECTION_CHANGE_CRITIC_HPP_
+
+#include "nav2_mppi_controller/critic_function.hpp"
+#include "nav2_mppi_controller/tools/utils.hpp"
+
+namespace mppi::critics
+{
+
+/**
+ * @class mppi::critics::DirectionChangeCritic
+ * @brief Critic objective function for penalizing changes in driving direction.
+ */
+class DirectionChangeCritic : public CriticFunction
+{
+public:
+  /**
+    * @brief Initialize critic
+    */
+  void initialize() override;
+
+  /**
+   * @brief Evaluate cost related to changing driving direction
+   *
+   * @param costs [out] add goal angle cost values to this tensor
+   */
+  void score(CriticData & data) override;
+
+protected:
+  unsigned int power_{0};
+  float weight_{0};
+  float threshold_to_consider_{0};
+  bool enforce_path_inversion_{false};
+};
+
+}  // namespace mppi::critics
+
+#endif  // NAV2_MPPI_CONTROLLER__CRITICS__DIRECTION_CHANGE_CRITIC_HPP_

--- a/nav2_mppi_controller/include/nav2_mppi_controller/critics/path_align_critic.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/critics/path_align_critic.hpp
@@ -51,6 +51,7 @@ protected:
   size_t offset_from_furthest_{0};
   int trajectory_point_step_{0};
   float threshold_to_consider_{0};
+  float occupancy_check_min_distance_{0};
   float max_path_occupancy_ratio_{0};
   bool use_path_orientations_{false};
   unsigned int power_{0};
@@ -58,6 +59,9 @@ protected:
 
   bool visualize_furthest_point_{false};
   nav2::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr furthest_point_pub_;
+
+  bool visualize_occupancy_check_distance_{false};
+  nav2::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr occupancy_check_dist_pub_;
 };
 
 }  // namespace mppi::critics

--- a/nav2_mppi_controller/include/nav2_mppi_controller/models/state.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/models/state.hpp
@@ -39,7 +39,8 @@ struct State
   Eigen::ArrayXXf cwz;
 
   geometry_msgs::msg::PoseStamped pose;
-  geometry_msgs::msg::Twist speed;  // current speed or last command published, depends on open_loop setting
+  // current speed or last command published, depends on open_loop setting
+  geometry_msgs::msg::Twist speed;
   geometry_msgs::msg::Twist robot_speed;  // current speed from odometry
   float local_path_length;
 

--- a/nav2_mppi_controller/include/nav2_mppi_controller/models/state.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/models/state.hpp
@@ -40,6 +40,7 @@ struct State
 
   geometry_msgs::msg::PoseStamped pose;
   geometry_msgs::msg::Twist speed;
+  geometry_msgs::msg::Twist robot_speed;
   float local_path_length;
 
   /**

--- a/nav2_mppi_controller/include/nav2_mppi_controller/models/state.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/models/state.hpp
@@ -39,8 +39,8 @@ struct State
   Eigen::ArrayXXf cwz;
 
   geometry_msgs::msg::PoseStamped pose;
-  geometry_msgs::msg::Twist speed;
-  geometry_msgs::msg::Twist robot_speed;
+  geometry_msgs::msg::Twist speed;  // current speed or last command published, depends on open_loop setting
+  geometry_msgs::msg::Twist robot_speed;  // current speed from odometry
   float local_path_length;
 
   /**

--- a/nav2_mppi_controller/src/critics/direction_change_critic.cpp
+++ b/nav2_mppi_controller/src/critics/direction_change_critic.cpp
@@ -45,10 +45,9 @@ void DirectionChangeCritic::score(CriticData & data)
 
   // Penalize the magnitude of velocity difference when crossing zero (direction change)
   // Calculate |vx - current_speed| only where signs differ, otherwise 0
-
+  // Use robot_speed from feedback, as it better represents the actual direction of motion
   constexpr size_t penalize_up_to_idx = 2;
-  const float current_speed = data.state.speed.linear.x;
-  std::cout << "critic speed: " << current_speed << std::endl;
+  const float current_speed = data.state.robot_speed.linear.x;
   // Process in-place using Eigen views to avoid allocations
   auto vx_view = data.state.vx.leftCols(penalize_up_to_idx);
 

--- a/nav2_mppi_controller/src/critics/direction_change_critic.cpp
+++ b/nav2_mppi_controller/src/critics/direction_change_critic.cpp
@@ -49,15 +49,21 @@ void DirectionChangeCritic::score(CriticData & data)
     return;
   }
 
+  // Penalize the magnitude of velocity difference when crossing zero (direction change)
+  // Calculate |vx - current_speed| only where signs differ, otherwise 0
+
   constexpr size_t penalize_up_to_idx = 2;
+  const float current_speed = data.state.speed.linear.x;
+  // Process in-place using Eigen views to avoid allocations
+  auto vx_view = data.state.vx.leftCols(penalize_up_to_idx);
+
+  // TODO also penalize change direction in wz (and vy for holonomic case) . maybe add a flag to enable/disable wz
   if (power_ > 1u) {
-    data.costs += (
-      // only penalize the first penalize_up_to_idx elements
-      (data.state.vx.leftCols(penalize_up_to_idx).unaryExpr([&](const float & x){return std::sign(x *
-        data.state.speed.linear.x);})).rowwise().sum() * weight_).pow(power_);
+    data.costs += ((vx_view * current_speed < 0.0f).select(
+      (vx_view - current_speed).abs(), 0.0f).rowwise().sum() * weight_).pow(power_);
   } else {
-    data.costs += (data.state.vx.leftCols(penalize_up_to_idx).unaryExpr([&](const float & x){
-      return std::sign(x * data.state.speed.linear.x);})).rowwise().sum() * weight_;
+    data.costs += (vx_view * current_speed < 0.0f).select(
+      (vx_view - current_speed).abs(), 0.0f).rowwise().sum() * weight_;
   }
 }
 

--- a/nav2_mppi_controller/src/critics/direction_change_critic.cpp
+++ b/nav2_mppi_controller/src/critics/direction_change_critic.cpp
@@ -51,7 +51,6 @@ void DirectionChangeCritic::score(CriticData & data)
   // Process in-place using Eigen views to avoid allocations
   auto vx_view = data.state.vx.leftCols(penalize_up_to_idx);
 
-  // TODO also penalize change direction in wz (and vy for holonomic case) . maybe add a flag to enable/disable wz
   if (power_ > 1u) {
     data.costs += ((vx_view * current_speed < 0.0f).select(
       (vx_view - current_speed).abs(), 0.0f).rowwise().sum() * weight_).pow(power_);

--- a/nav2_mppi_controller/src/critics/direction_change_critic.cpp
+++ b/nav2_mppi_controller/src/critics/direction_change_critic.cpp
@@ -22,8 +22,6 @@ namespace mppi::critics
 void DirectionChangeCritic::initialize()
 {
   auto getParentParam = parameters_handler_->getParamGetter(parent_name_);
-  getParentParam(enforce_path_inversion_, "enforce_path_inversion", false);
-
   auto getParam = parameters_handler_->getParamGetter(name_);
   getParam(power_, "cost_power", 1);
   getParam(weight_, "cost_weight", 5.0f);
@@ -41,11 +39,7 @@ void DirectionChangeCritic::score(CriticData & data)
     return;
   }
 
-  geometry_msgs::msg::Pose goal = utils::getCriticGoal(data, enforce_path_inversion_);
-
-  if (utils::withinPositionGoalTolerance(
-      threshold_to_consider_, data.state.pose.pose, goal))
-  {
+  if (data.state.local_path_length < threshold_to_consider_) {
     return;
   }
 

--- a/nav2_mppi_controller/src/critics/direction_change_critic.cpp
+++ b/nav2_mppi_controller/src/critics/direction_change_critic.cpp
@@ -1,0 +1,70 @@
+// Copyright (c) 2024 Enway GmbH, Adi Vardi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "nav2_mppi_controller/critics/direction_change_critic.hpp"
+
+#include <Eigen/Dense>
+
+namespace mppi::critics
+{
+
+void DirectionChangeCritic::initialize()
+{
+  auto getParentParam = parameters_handler_->getParamGetter(parent_name_);
+  getParentParam(enforce_path_inversion_, "enforce_path_inversion", false);
+
+  auto getParam = parameters_handler_->getParamGetter(name_);
+  getParam(power_, "cost_power", 1);
+  getParam(weight_, "cost_weight", 5.0f);
+  getParam(
+    threshold_to_consider_,
+    "threshold_to_consider", 0.5f);
+
+  RCLCPP_INFO(
+    logger_, "DirectionChangeCritic instantiated with %d power and %f weight.", power_, weight_);
+}
+
+void DirectionChangeCritic::score(CriticData & data)
+{
+  if (!enabled_) {
+    return;
+  }
+
+  geometry_msgs::msg::Pose goal = utils::getCriticGoal(data, enforce_path_inversion_);
+
+  if (utils::withinPositionGoalTolerance(
+      threshold_to_consider_, data.state.pose.pose, goal))
+  {
+    return;
+  }
+
+  constexpr size_t penalize_up_to_idx = 2;
+  if (power_ > 1u) {
+    data.costs += (
+      // only penalize the first penalize_up_to_idx elements
+      (data.state.vx.leftCols(penalize_up_to_idx).unaryExpr([&](const float & x){return std::sign(x *
+        data.state.speed.linear.x);})).rowwise().sum() * weight_).pow(power_);
+  } else {
+    data.costs += (data.state.vx.leftCols(penalize_up_to_idx).unaryExpr([&](const float & x){
+      return std::sign(x * data.state.speed.linear.x);})).rowwise().sum() * weight_;
+  }
+}
+
+}  // namespace mppi::critics
+
+#include <pluginlib/class_list_macros.hpp>
+
+PLUGINLIB_EXPORT_CLASS(
+  mppi::critics::DirectionChangeCritic,
+  mppi::critics::CriticFunction)

--- a/nav2_mppi_controller/src/critics/direction_change_critic.cpp
+++ b/nav2_mppi_controller/src/critics/direction_change_critic.cpp
@@ -53,7 +53,7 @@ void DirectionChangeCritic::score(CriticData & data)
 
   if (power_ > 1u) {
     data.costs += ((vx_view * current_speed < 0.0f).select(
-      (vx_view - current_speed).abs(), 0.0f).rowwise().sum() * weight_).pow(power_);
+        (vx_view - current_speed).abs(), 0.0f).rowwise().sum() * weight_).pow(power_);
   } else {
     data.costs += (vx_view * current_speed < 0.0f).select(
       (vx_view - current_speed).abs(), 0.0f).rowwise().sum() * weight_;

--- a/nav2_mppi_controller/src/critics/direction_change_critic.cpp
+++ b/nav2_mppi_controller/src/critics/direction_change_critic.cpp
@@ -48,6 +48,7 @@ void DirectionChangeCritic::score(CriticData & data)
 
   constexpr size_t penalize_up_to_idx = 2;
   const float current_speed = data.state.speed.linear.x;
+  std::cout << "critic speed: " << current_speed << std::endl;
   // Process in-place using Eigen views to avoid allocations
   auto vx_view = data.state.vx.leftCols(penalize_up_to_idx);
 

--- a/nav2_mppi_controller/src/critics/path_align_critic.cpp
+++ b/nav2_mppi_controller/src/critics/path_align_critic.cpp
@@ -53,11 +53,16 @@ void PathAlignCritic::score(CriticData & data)
     return;
   }
 
-  // Don't apply when first getting bearing w.r.t. the path
+  // Only apply critic when trajectories reach far enough along the way path.
+  // This ensures that path alignment is only considered when actually tracking the path (e.g. not driving very slow
+  // or when first getting bearing w.r.t. the path)
   utils::setPathFurthestPointIfNotSet(data);
-  // Up to furthest only, closest path point is always 0 from path handler
-  const size_t path_segments_count = *data.furthest_reached_path_point;
-  float path_segments_flt = static_cast<float>(path_segments_count);
+  if (*data.furthest_reached_path_point < offset_from_furthest_) {
+    return;
+  }
+
+  // use the whole local path as reference path
+  const size_t path_segments_count = data.path.x.size() - 1;
 
   // Visualize target pose if enabled
   if (visualize_furthest_point_ && path_segments_count > 0 &&
@@ -75,17 +80,14 @@ void PathAlignCritic::score(CriticData & data)
     furthest_point_pub_->publish(std::move(furthest_point));
   }
 
-  if (path_segments_count < offset_from_furthest_) {
-    return;
-  }
-
   // Don't apply when dynamic obstacles are blocking significant proportions of the local path
+  const float path_segments_count_flt = static_cast<float>(path_segments_count);
   utils::setPathCostsIfNotSet(data, costmap_ros_);
   std::vector<bool> & path_pts_valid = *data.path_pts_valid;
   float invalid_ctr = 0.0f;
   for (size_t i = 0; i < path_segments_count; i++) {
     if (!path_pts_valid[i]) {invalid_ctr += 1.0f;}
-    if (invalid_ctr / path_segments_flt > max_path_occupancy_ratio_ && invalid_ctr > 2.0f) {
+    if (invalid_ctr / path_segments_count_flt > max_path_occupancy_ratio_ && invalid_ctr > 2.0f) {
       return;
     }
   }

--- a/nav2_mppi_controller/src/critics/path_align_critic.cpp
+++ b/nav2_mppi_controller/src/critics/path_align_critic.cpp
@@ -66,8 +66,8 @@ void PathAlignCritic::score(CriticData & data)
   }
 
   // Only apply critic when trajectories reach far enough along the way path.
-  // This ensures that path alignment is only considered when actually tracking the path (e.g. not driving very slow
-  // or when first getting bearing w.r.t. the path)
+  // This ensures that path alignment is only considered when actually tracking the path
+  // (e.g. not driving very slow or when first getting bearing w.r.t. the path)
   utils::setPathFurthestPointIfNotSet(data);
 
   const auto now = clock_->now();
@@ -95,7 +95,9 @@ void PathAlignCritic::score(CriticData & data)
   Eigen::ArrayXf cost(data.costs.rows());
   cost.setZero();
 
-  // Find integrated arc-length distance along the path = total dist traveled along the path to each path point
+  // Find integrated arc-length distance along the path = total dist traveled along the path to each
+  // path point loop until end of path, to guarantee don't truncate long trajectories when furthest
+  // reached path is small (e.g. when all traj curve away from the path)
   const size_t path_segments_count = data.path.x.size() - 1;
   // initialize the occupancy check id to max, in case the entire path is within the distance
   size_t occupancy_check_distance_idx = path_segments_count;
@@ -112,7 +114,8 @@ void PathAlignCritic::score(CriticData & data)
     dy = data.path.y(i) - pose.y;
     path_integrated_distances[i] = path_integrated_distances[i - 1] + sqrtf(dx * dx + dy * dy);
 
-    // find the first path point that is further than  max(occupancy_check_min_distance_, furthest_reached_path_point)
+    // find the first path point that is further than
+    //  max(occupancy_check_min_distance_, furthest_reached_path_point)
     if (occupancy_check_distance_idx == path_segments_count &&
         path_integrated_distances[i] > occupancy_check_min_distance_ &&
         i >= *data.furthest_reached_path_point) {
@@ -136,14 +139,16 @@ void PathAlignCritic::score(CriticData & data)
     occupancy_check_dist_pub_->publish(std::move(occupancy_check_point));
   }
 
-  // Don't apply when dynamic obstacles are blocking significant proportions of the path up to occupancy_check_min_distance_
+  // Don't apply when dynamic obstacles are blocking significant proportions of the path
+  // up to occupancy_check_min_distance_
   const float occupancy_check_distance_idx_flt = static_cast<float>(occupancy_check_distance_idx);
   utils::setPathCostsIfNotSet(data, costmap_ros_);
   std::vector<bool> & path_pts_valid = *data.path_pts_valid;
   float invalid_ctr = 0.0f;
   for (size_t i = 0; i < occupancy_check_distance_idx; i++) {
     if (!path_pts_valid[i]) {invalid_ctr += 1.0f;}
-    if (invalid_ctr / occupancy_check_distance_idx_flt > max_path_occupancy_ratio_ && invalid_ctr > 2.0f) {
+    if (invalid_ctr / occupancy_check_distance_idx_flt > max_path_occupancy_ratio_ &&
+        invalid_ctr > 2.0f) {
       return;
     }
   }

--- a/nav2_mppi_controller/src/critics/path_align_critic.cpp
+++ b/nav2_mppi_controller/src/critics/path_align_critic.cpp
@@ -112,7 +112,7 @@ void PathAlignCritic::score(CriticData & data)
     dy = data.path.y(i) - pose.y;
     path_integrated_distances[i] = path_integrated_distances[i - 1] + sqrtf(dx * dx + dy * dy);
 
-    // find the first path point that is further along the path than the occupancy_check_min_distance_ and
+    // find the first path point that is further than  max(occupancy_check_min_distance_, furthest_reached_path_point)
     if (occupancy_check_distance_idx == path_segments_count &&
         path_integrated_distances[i] > occupancy_check_min_distance_ &&
         i >= *data.furthest_reached_path_point) {

--- a/nav2_mppi_controller/src/critics/path_align_critic.cpp
+++ b/nav2_mppi_controller/src/critics/path_align_critic.cpp
@@ -41,6 +41,15 @@ void PathAlignCritic::initialize()
     }
   }
 
+  // TODO
+  // if (visualize_occupancy_check_point_) {
+  //   auto node = parent_.lock();
+  //   if (node) {
+  //     occupancy_check_point_pub_ = node->create_publisher<geometry_msgs::msg::PoseStamped>(
+  //       "PathAlignCritic/occupancy_check_point", 1);
+  //     occupancy_check_point_pub_->on_activate();
+  //   }
+  // }
   RCLCPP_INFO(
     logger_,
     "ReferenceTrajectoryCritic instantiated with %d power and %f weight",
@@ -61,42 +70,20 @@ void PathAlignCritic::score(CriticData & data)
     return;
   }
 
-  // use the whole local path as reference path
-  const size_t path_segments_count = data.path.x.size() - 1;
-
-  // Visualize target pose if enabled
-  if (visualize_furthest_point_ && path_segments_count > 0 &&
-    furthest_point_pub_->get_subscription_count() > 0)
-  {
-    auto furthest_point = std::make_unique<geometry_msgs::msg::PoseStamped>();
-    furthest_point->header.frame_id = costmap_ros_->getGlobalFrameID();
-    furthest_point->header.stamp = clock_->now();
-    furthest_point->pose.position.x = data.path.x(path_segments_count);
-    furthest_point->pose.position.y = data.path.y(path_segments_count);
-    furthest_point->pose.position.z = 0.0;
-    tf2::Quaternion quat;
-    quat.setRPY(0.0, 0.0, data.path.yaws(path_segments_count));
-    furthest_point->pose.orientation = tf2::toMsg(quat);
-    furthest_point_pub_->publish(std::move(furthest_point));
-  }
-
-  // Don't apply when dynamic obstacles are blocking significant proportions of the local path
-  const float path_segments_count_flt = static_cast<float>(path_segments_count);
-  utils::setPathCostsIfNotSet(data, costmap_ros_);
-  std::vector<bool> & path_pts_valid = *data.path_pts_valid;
-  float invalid_ctr = 0.0f;
-  for (size_t i = 0; i < path_segments_count; i++) {
-    if (!path_pts_valid[i]) {invalid_ctr += 1.0f;}
-    if (invalid_ctr / path_segments_count_flt > max_path_occupancy_ratio_ && invalid_ctr > 2.0f) {
-      return;
-    }
-  }
-
   const size_t batch_size = data.trajectories.x.rows();
   Eigen::ArrayXf cost(data.costs.rows());
   cost.setZero();
 
+  const size_t path_size = data.path.x.size();
+
+  constexpr float occupancy_check_distance = 5.0; // TODO make into a parameter
+                                                  // TODO what if smaller than furthest_reached_path_point
+  size_t occupancy_check_distance_idx = path_size; // initialize to max, in case the whole path is within the occupancy_check_distance
+
   // Find integrated arc-length distance along the path = total dist traveled along the path to each path point
+  // TODO path_segments_count can be reduced, but should be at least max(occupancy_check_distance_idx, furthest_reached_path_point)
+  //      but we don't have occupancy_check_distance_idx before the next loop... so maybe we can break the loop when reached
+  const size_t path_segments_count = path_size;
   std::vector<float> path_integrated_distances(path_segments_count, 0.0f);
   std::vector<utils::Pose2D> path(path_segments_count);
   float dx = 0.0f, dy = 0.0f;
@@ -109,6 +96,41 @@ void PathAlignCritic::score(CriticData & data)
     dx = data.path.x(i) - pose.x;
     dy = data.path.y(i) - pose.y;
     path_integrated_distances[i] = path_integrated_distances[i - 1] + sqrtf(dx * dx + dy * dy);
+
+    // find the first path point that is further along the path than the occupancy_check_distance
+    if (path_integrated_distances[i] > occupancy_check_distance && occupancy_check_distance_idx == path_size) {
+      occupancy_check_distance_idx = i;
+    }
+  }
+
+  // Visualize target pose if enabled
+  // TODO separate publisher for furthest_point_pub_ (published before <offset_from_furthest_ check, like upstream)
+  // TODO and a publisher for occupancy_check_distance point
+  if (visualize_furthest_point_ && occupancy_check_distance_idx > 0 &&
+    furthest_point_pub_->get_subscription_count() > 0)
+  {
+    auto furthest_point = std::make_unique<geometry_msgs::msg::PoseStamped>();
+    furthest_point->header.frame_id = costmap_ros_->getGlobalFrameID();
+    furthest_point->header.stamp = clock_->now();
+    furthest_point->pose.position.x = data.path.x(occupancy_check_distance_idx);
+    furthest_point->pose.position.y = data.path.y(occupancy_check_distance_idx);
+    furthest_point->pose.position.z = 0.0;
+    tf2::Quaternion quat;
+    quat.setRPY(0.0, 0.0, data.path.yaws(occupancy_check_distance_idx));
+    furthest_point->pose.orientation = tf2::toMsg(quat);
+    furthest_point_pub_->publish(std::move(furthest_point));
+  }
+
+  // Don't apply when dynamic obstacles are blocking significant proportions of the path up to occupancy_check_distance
+  const float occupancy_check_distance_idx_flt = static_cast<float>(occupancy_check_distance_idx);
+  utils::setPathCostsIfNotSet(data, costmap_ros_);
+  std::vector<bool> & path_pts_valid = *data.path_pts_valid;
+  float invalid_ctr = 0.0f;
+  for (size_t i = 0; i < occupancy_check_distance_idx; i++) {
+    if (!path_pts_valid[i]) {invalid_ctr += 1.0f;}
+    if (invalid_ctr / occupancy_check_distance_idx_flt > max_path_occupancy_ratio_ && invalid_ctr > 2.0f) {
+      return;
+    }
   }
 
   // Finish populating the path vector

--- a/nav2_mppi_controller/src/critics/path_align_critic.cpp
+++ b/nav2_mppi_controller/src/critics/path_align_critic.cpp
@@ -94,7 +94,7 @@ void PathAlignCritic::score(CriticData & data)
   Eigen::ArrayXf cost(data.costs.rows());
   cost.setZero();
 
-  // Find integrated distance in the path
+  // Find integrated arc-length distance along the path = total dist traveled along the path to each path point
   std::vector<float> path_integrated_distances(path_segments_count, 0.0f);
   std::vector<utils::Pose2D> path(path_segments_count);
   float dx = 0.0f, dy = 0.0f;

--- a/nav2_mppi_controller/src/critics/path_align_critic.cpp
+++ b/nav2_mppi_controller/src/critics/path_align_critic.cpp
@@ -117,8 +117,9 @@ void PathAlignCritic::score(CriticData & data)
     // find the first path point that is further than
     //  max(occupancy_check_min_distance_, furthest_reached_path_point)
     if (occupancy_check_distance_idx == path_segments_count &&
-        path_integrated_distances[i] > occupancy_check_min_distance_ &&
-        i >= *data.furthest_reached_path_point) {
+      path_integrated_distances[i] > occupancy_check_min_distance_ &&
+      i >= *data.furthest_reached_path_point)
+    {
       occupancy_check_distance_idx = i;
     }
   }
@@ -148,7 +149,8 @@ void PathAlignCritic::score(CriticData & data)
   for (size_t i = 0; i < occupancy_check_distance_idx; i++) {
     if (!path_pts_valid[i]) {invalid_ctr += 1.0f;}
     if (invalid_ctr / occupancy_check_distance_idx_flt > max_path_occupancy_ratio_ &&
-        invalid_ctr > 2.0f) {
+      invalid_ctr > 2.0f)
+    {
       return;
     }
   }

--- a/nav2_mppi_controller/src/critics/path_align_critic.cpp
+++ b/nav2_mppi_controller/src/critics/path_align_critic.cpp
@@ -23,6 +23,7 @@ void PathAlignCritic::initialize()
   auto getParam = parameters_handler_->getParamGetter(name_);
   getParam(power_, "cost_power", 1);
   getParam(weight_, "cost_weight", 10.0f);
+  getParam(occupancy_check_min_distance_, "occupancy_check_min_distance", 2.0f);
   getParam(max_path_occupancy_ratio_, "max_path_occupancy_ratio", 0.07f);
   getParam(offset_from_furthest_, "offset_from_furthest", 20);
   getParam(trajectory_point_step_, "trajectory_point_step", 4);
@@ -41,15 +42,17 @@ void PathAlignCritic::initialize()
     }
   }
 
-  // TODO
-  // if (visualize_occupancy_check_point_) {
-  //   auto node = parent_.lock();
-  //   if (node) {
-  //     occupancy_check_point_pub_ = node->create_publisher<geometry_msgs::msg::PoseStamped>(
-  //       "PathAlignCritic/occupancy_check_point", 1);
-  //     occupancy_check_point_pub_->on_activate();
-  //   }
-  // }
+  getParam(visualize_occupancy_check_distance_, "visualize_occupancy_check_distance", false);
+
+  if (visualize_occupancy_check_distance_) {
+    auto node = parent_.lock();
+    if (node) {
+      occupancy_check_dist_pub_ = node->create_publisher<geometry_msgs::msg::PoseStamped>(
+        "PathAlignCritic/occupancy_check_end_point", 1);
+      occupancy_check_dist_pub_->on_activate();
+    }
+  }
+
   RCLCPP_INFO(
     logger_,
     "ReferenceTrajectoryCritic instantiated with %d power and %f weight",
@@ -66,6 +69,24 @@ void PathAlignCritic::score(CriticData & data)
   // This ensures that path alignment is only considered when actually tracking the path (e.g. not driving very slow
   // or when first getting bearing w.r.t. the path)
   utils::setPathFurthestPointIfNotSet(data);
+
+  const auto now = clock_->now();
+  // Visualize furthest reached pose if enabled
+  if (visualize_furthest_point_ && *data.furthest_reached_path_point > 0 &&
+    furthest_point_pub_->get_subscription_count() > 0)
+  {
+    auto furthest_point = std::make_unique<geometry_msgs::msg::PoseStamped>();
+    furthest_point->header.frame_id = costmap_ros_->getGlobalFrameID();
+    furthest_point->header.stamp = now;
+    furthest_point->pose.position.x = data.path.x(*data.furthest_reached_path_point);
+    furthest_point->pose.position.y = data.path.y(*data.furthest_reached_path_point);
+    furthest_point->pose.position.z = 0.0;
+    tf2::Quaternion quat;
+    quat.setRPY(0.0, 0.0, data.path.yaws(*data.furthest_reached_path_point));
+    furthest_point->pose.orientation = tf2::toMsg(quat);
+    furthest_point_pub_->publish(std::move(furthest_point));
+  }
+
   if (*data.furthest_reached_path_point < offset_from_furthest_) {
     return;
   }
@@ -74,16 +95,13 @@ void PathAlignCritic::score(CriticData & data)
   Eigen::ArrayXf cost(data.costs.rows());
   cost.setZero();
 
-  const size_t path_size = data.path.x.size();
-
-  constexpr float occupancy_check_distance = 5.0; // TODO make into a parameter
-                                                  // TODO what if smaller than furthest_reached_path_point
-  size_t occupancy_check_distance_idx = path_size; // initialize to max, in case the whole path is within the occupancy_check_distance
-
   // Find integrated arc-length distance along the path = total dist traveled along the path to each path point
-  // TODO path_segments_count can be reduced, but should be at least max(occupancy_check_distance_idx, furthest_reached_path_point)
+  // TODO the integration doesn't have to be until the end of the path but should be at least
+  //      max(occupancy_check_distance_idx, furthest_reached_path_point)
   //      but we don't have occupancy_check_distance_idx before the next loop... so maybe we can break the loop when reached
-  const size_t path_segments_count = path_size;
+  const size_t path_segments_count = data.path.x.size() - 1;
+  // initialize the occupancy check id to max, in case the entire path is within the distance
+  size_t occupancy_check_distance_idx = path_segments_count;
   std::vector<float> path_integrated_distances(path_segments_count, 0.0f);
   std::vector<utils::Pose2D> path(path_segments_count);
   float dx = 0.0f, dy = 0.0f;
@@ -97,31 +115,30 @@ void PathAlignCritic::score(CriticData & data)
     dy = data.path.y(i) - pose.y;
     path_integrated_distances[i] = path_integrated_distances[i - 1] + sqrtf(dx * dx + dy * dy);
 
-    // find the first path point that is further along the path than the occupancy_check_distance
-    if (path_integrated_distances[i] > occupancy_check_distance && occupancy_check_distance_idx == path_size) {
+    // find the first path point that is further along the path than the occupancy_check_min_distance_
+    // TODO what if smaller than furthest_reached_path_point
+    if (path_integrated_distances[i] > occupancy_check_min_distance_ && occupancy_check_distance_idx == path_segments_count) {
       occupancy_check_distance_idx = i;
     }
   }
 
-  // Visualize target pose if enabled
-  // TODO separate publisher for furthest_point_pub_ (published before <offset_from_furthest_ check, like upstream)
-  // TODO and a publisher for occupancy_check_distance point
-  if (visualize_furthest_point_ && occupancy_check_distance_idx > 0 &&
-    furthest_point_pub_->get_subscription_count() > 0)
+  // Visualize occupancy check distance if enabled
+  if (visualize_occupancy_check_distance_ &&
+    occupancy_check_dist_pub_->get_subscription_count() > 0)
   {
-    auto furthest_point = std::make_unique<geometry_msgs::msg::PoseStamped>();
-    furthest_point->header.frame_id = costmap_ros_->getGlobalFrameID();
-    furthest_point->header.stamp = clock_->now();
-    furthest_point->pose.position.x = data.path.x(occupancy_check_distance_idx);
-    furthest_point->pose.position.y = data.path.y(occupancy_check_distance_idx);
-    furthest_point->pose.position.z = 0.0;
+    auto occupancy_check_point = std::make_unique<geometry_msgs::msg::PoseStamped>();
+    occupancy_check_point->header.frame_id = costmap_ros_->getGlobalFrameID();
+    occupancy_check_point->header.stamp = now;
+    occupancy_check_point->pose.position.x = data.path.x(occupancy_check_distance_idx);
+    occupancy_check_point->pose.position.y = data.path.y(occupancy_check_distance_idx);
+    occupancy_check_point->pose.position.z = 0.0;
     tf2::Quaternion quat;
     quat.setRPY(0.0, 0.0, data.path.yaws(occupancy_check_distance_idx));
-    furthest_point->pose.orientation = tf2::toMsg(quat);
-    furthest_point_pub_->publish(std::move(furthest_point));
+    occupancy_check_point->pose.orientation = tf2::toMsg(quat);
+    occupancy_check_dist_pub_->publish(std::move(occupancy_check_point));
   }
 
-  // Don't apply when dynamic obstacles are blocking significant proportions of the path up to occupancy_check_distance
+  // Don't apply when dynamic obstacles are blocking significant proportions of the path up to occupancy_check_min_distance_
   const float occupancy_check_distance_idx_flt = static_cast<float>(occupancy_check_distance_idx);
   utils::setPathCostsIfNotSet(data, costmap_ros_);
   std::vector<bool> & path_pts_valid = *data.path_pts_valid;

--- a/nav2_mppi_controller/src/critics/path_align_critic.cpp
+++ b/nav2_mppi_controller/src/critics/path_align_critic.cpp
@@ -96,9 +96,6 @@ void PathAlignCritic::score(CriticData & data)
   cost.setZero();
 
   // Find integrated arc-length distance along the path = total dist traveled along the path to each path point
-  // TODO the integration doesn't have to be until the end of the path but should be at least
-  //      max(occupancy_check_distance_idx, furthest_reached_path_point)
-  //      but we don't have occupancy_check_distance_idx before the next loop... so maybe we can break the loop when reached
   const size_t path_segments_count = data.path.x.size() - 1;
   // initialize the occupancy check id to max, in case the entire path is within the distance
   size_t occupancy_check_distance_idx = path_segments_count;
@@ -115,9 +112,10 @@ void PathAlignCritic::score(CriticData & data)
     dy = data.path.y(i) - pose.y;
     path_integrated_distances[i] = path_integrated_distances[i - 1] + sqrtf(dx * dx + dy * dy);
 
-    // find the first path point that is further along the path than the occupancy_check_min_distance_
-    // TODO what if smaller than furthest_reached_path_point
-    if (path_integrated_distances[i] > occupancy_check_min_distance_ && occupancy_check_distance_idx == path_segments_count) {
+    // find the first path point that is further along the path than the occupancy_check_min_distance_ and
+    if (occupancy_check_distance_idx == path_segments_count &&
+        path_integrated_distances[i] > occupancy_check_min_distance_ &&
+        i >= *data.furthest_reached_path_point) {
       occupancy_check_distance_idx = i;
     }
   }

--- a/nav2_mppi_controller/src/critics/path_align_critic.cpp
+++ b/nav2_mppi_controller/src/critics/path_align_critic.cpp
@@ -48,7 +48,7 @@ void PathAlignCritic::initialize()
     auto node = parent_.lock();
     if (node) {
       occupancy_check_dist_pub_ = node->create_publisher<geometry_msgs::msg::PoseStamped>(
-        "PathAlignCritic/occupancy_check_end_point", 1);
+          "/critics/PathAlignCritic/occupancy_check_end_point", 1);
       occupancy_check_dist_pub_->on_activate();
     }
   }

--- a/nav2_mppi_controller/src/critics/path_align_critic.cpp
+++ b/nav2_mppi_controller/src/critics/path_align_critic.cpp
@@ -96,8 +96,9 @@ void PathAlignCritic::score(CriticData & data)
   cost.setZero();
 
   // Find integrated arc-length distance along the path = total dist traveled along the path to each
-  // path point loop until end of path, to guarantee don't truncate long trajectories when furthest
-  // reached path is small (e.g. when all traj curve away from the path)
+  // path point
+  // loop until end of path, to guarantee don't truncate long trajectories when
+  // furthest_reached_path_point is small (e.g. when all trajectories curve away from the path)
   const size_t path_segments_count = data.path.x.size() - 1;
   // initialize the occupancy check id to max, in case the entire path is within the distance
   size_t occupancy_check_distance_idx = path_segments_count;
@@ -191,6 +192,10 @@ void PathAlignCritic::score(CriticData & data)
     path_pt = 0u;
     float Tx_m1 = T_x(t, 0);
     float Ty_m1 = T_y(t, 0);
+    // At each (strided) traj point, find the path point whose integrated arc-length distance along
+    // the path is closest to the trajectory point's integrated distance along the trajectory.
+    // if that path point is not in collision, compute the Euclidean distance between the matching
+    // path pt & traj pt the total cost is the average of those distances across the trajectory
     for (int p = 1; p < traj_sampled_size; p++) {
       const float Tx = T_x(t, p);
       const float Ty = T_y(t, p);

--- a/nav2_mppi_controller/src/optimizer.cpp
+++ b/nav2_mppi_controller/src/optimizer.cpp
@@ -297,6 +297,11 @@ void Optimizer::prepare(
 {
   state_.pose = robot_pose;
   state_.speed = settings_.open_loop ? last_command_vel_ : robot_speed;
+  state_.robot_speed = robot_speed;
+  std::cout << "last_command_vel_.linear.x: " << last_command_vel_.linear.x << std::endl;
+  std::cout << "robot_speed.linear.x: " << robot_speed.linear.x << std::endl;
+  std::cout << "state_.speed.linear.x: " << state_.speed.linear.x << std::endl;
+
   state_.local_path_length = nav2_util::geometry_utils::calculate_path_length(plan);
   path_ = utils::toTensor(plan);
   costs_.setZero(settings_.batch_size);

--- a/nav2_mppi_controller/src/optimizer.cpp
+++ b/nav2_mppi_controller/src/optimizer.cpp
@@ -298,9 +298,6 @@ void Optimizer::prepare(
   state_.pose = robot_pose;
   state_.speed = settings_.open_loop ? last_command_vel_ : robot_speed;
   state_.robot_speed = robot_speed;
-  std::cout << "last_command_vel_.linear.x: " << last_command_vel_.linear.x << std::endl;
-  std::cout << "robot_speed.linear.x: " << robot_speed.linear.x << std::endl;
-  std::cout << "state_.speed.linear.x: " << state_.speed.linear.x << std::endl;
 
   state_.local_path_length = nav2_util::geometry_utils::calculate_path_length(plan);
   path_ = utils::toTensor(plan);


### PR DESCRIPTION
## Additions & Changes
### PathAlign Critic
Add a minimum distance for the occupancy check.
Previously, the occupancy check was done up to a distance = furthest_reached_path_point along the path,
Now, it is done over a `distance = min(min_dist, furthest_reached_path_point)`.

The effect of this change is that when approaching an obstacle, even if the robot slows down (and thus `furthest_reached_path_point` distance becomes smaller and smaller), the check would still trigger and disable the critic. This solves the issue where the robot slows down when approaching an obstacle instead of overtaking it, until it gets stuck when the obstacle is just in front of the robot.

Results of this change are susbtiantal:
Previously, robot was not able to overtake a box of 1.5m width places in front of it.
With the change, the robot can overtake obstacles up to the width of a car and even more.

#### Remaining issues
When approaching a car parked perpendicular to the robot, the robot correctly starts going around it. However, when the robot is perpendicular to the path, MPPI finds no good solution and "gets lost"

### DirectionChange Critic
Add a critic for penalizing changes in driving direction. This reduces MPPI switching direction too quickly, leading to robot to get stuck as the motors cannot follow.

Applying the critic on the current robot's speed (and not last command published) leads to much better results

Added a new `state.robot_speed` field as `state.speed` is either current speed or last command published, depends on open_loop setting.

#### Remaining issues
`DirectionChange`: Also penalize wz to avoid quick steering in place when stuck

### Checklist (tick off when done or remove when not relevant):
- [x] Set good PR title for changelog
- [x] Perform a self-review if the PR has more than 50 lines of changes
