### PR TITLE
only reload BTs if any file changed, full clear BTs

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/behavior_tree_engine.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/behavior_tree_engine.hpp
@@ -132,6 +132,13 @@ public:
   void registerTreeFromFile(const std::string & file_path);
 
   /**
+   * @brief Clear all previously registered behavior trees from the factory's
+   * internal XML parser state.  This prevents the parser's opened_documents
+   * list from growing unboundedly when trees are re-registered (memory leak).
+   */
+  void clearRegisteredBehaviorTrees();
+
+  /**
    * @brief Function to explicitly reset all BT nodes to initial state
    * @param tree Tree to halt
    */

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server.hpp
@@ -16,9 +16,11 @@
 #define NAV2_BEHAVIOR_TREE__BT_ACTION_SERVER_HPP_
 
 #include <chrono>
+#include <filesystem>
 #include <functional>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "geometry_msgs/msg/pose_stamped.hpp"
@@ -304,6 +306,10 @@ protected:
   // internal error tracking (IOW not behaviorTree blackboard errors)
   uint16_t internal_error_code_;
   std::string internal_error_msg_;
+
+  // File-modification cache: used by always_reload_bt_xml mode to skip
+  // a full tree rebuild when no XML file has been touched on disk.
+  std::unordered_map<std::string, std::filesystem::file_time_type> bt_xml_mtimes_;
 };
 
 }  // namespace nav2_behavior_tree

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -258,7 +258,7 @@ bool BtActionServer<ActionT, NodeT>::loadBehaviorTree(const std::string & bt_xml
   // interfaces) on every goal otherwise causes unbounded memory growth in both the BT factory's
   // internal XML parser and the ROS / DDS middleware layer.
   if (always_reload_bt_ && current_bt_file_or_id_ == file_or_id) {
-    bool any_changed = bt_xml_mtimes_.empty(); // no snapshot: force reload
+    bool any_changed = bt_xml_mtimes_.empty();  // no snapshot: force reload
     try {
       for (const auto & [path, old_mtime] : bt_xml_mtimes_) {
         if (fs::last_write_time(path) != old_mtime) {
@@ -267,7 +267,7 @@ bool BtActionServer<ActionT, NodeT>::loadBehaviorTree(const std::string & bt_xml
         }
       }
     } catch (const std::filesystem::filesystem_error &) {
-      any_changed = true; // file vanished or became inaccessible: force reload
+      any_changed = true;  // file vanished or became inaccessible: force reload
     }
     if (!any_changed) {
       RCLCPP_DEBUG(logger_, "BT XML files unchanged on disk, skipping reload");

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -253,6 +253,41 @@ bool BtActionServer<ActionT, NodeT>::loadBehaviorTree(const std::string & bt_xml
     return true;
   }
 
+  // When always_reload_bt_ is true and the same BT is requested, only perform
+  // the expensive full reload if at least one XML file on disk actually changed.
+  // Recreating the behaviour-tree (and its ROS action-client / pub-sub
+  // resources) on every goal otherwise causes unbounded memory growth in both
+  // the BT factory's internal XML parser and the ROS / DDS middleware layer.
+  if (always_reload_bt_ && current_bt_file_or_id_ == file_or_id) {
+    bool any_changed = false;
+    try {
+      for (const auto & [path, old_mtime] : bt_xml_mtimes_) {
+        if (fs::last_write_time(path) != old_mtime) {
+          any_changed = true;
+          break;
+        }
+      }
+    } catch (const std::filesystem::filesystem_error &) {
+      any_changed = true;  // file vanished or became inaccessible; force reload
+    }
+    if (!any_changed) {
+      RCLCPP_DEBUG(logger_, "BT XML files unchanged on disk, skipping reload");
+      return true;
+    }
+    RCLCPP_INFO(logger_, "BT XML file(s) modified on disk, reloading tree");
+  }
+
+  // When reloading an already-loaded BT, clean up all resources before
+  // re-registering.  The BT factory's internal XML parser appends a new
+  // XMLDocument on each registerBehaviorTreeFromFile() call; clearing the
+  // parser state here keeps that list bounded and prevents a secondary leak.
+  if (!current_bt_file_or_id_.empty()) {
+    topic_logger_.reset();
+    bt_->haltAllActions(tree_);
+    tree_ = BT::Tree{};
+    bt_->clearRegisteredBehaviorTrees();
+  }
+
   // Reset any existing Groot2 monitoring
   bt_->resetGrootMonitor();
 
@@ -393,6 +428,23 @@ bool BtActionServer<ActionT, NodeT>::loadBehaviorTree(const std::string & bt_xml
     RCLCPP_DEBUG(
       logger_, "Enabling Groot2 monitoring for %s: %d",
       action_name_.c_str(), groot_server_port_);
+  }
+
+  // Snapshot file modification times so that the next call with
+  // always_reload_bt_ can tell whether any XML actually changed.
+  if (always_reload_bt_) {
+    bt_xml_mtimes_.clear();
+    // Track the main file when it is specified as a path (not an ID)
+    if (!is_bt_id) {
+      bt_xml_mtimes_[file_or_id] = fs::last_write_time(file_or_id);
+    }
+    for (const auto & directory : search_directories_) {
+      for (const auto & entry : fs::directory_iterator(directory)) {
+        if (entry.path().extension() == ".xml") {
+          bt_xml_mtimes_[entry.path().string()] = fs::last_write_time(entry.path());
+        }
+      }
+    }
   }
 
   return true;

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -253,11 +253,10 @@ bool BtActionServer<ActionT, NodeT>::loadBehaviorTree(const std::string & bt_xml
     return true;
   }
 
-  // When always_reload_bt_ is true and the same BT is requested, only perform
-  // the expensive full reload if at least one XML file on disk actually changed.
-  // Recreating the behaviour-tree (and its ROS action-client / pub-sub
-  // resources) on every goal otherwise causes unbounded memory growth in both
-  // the BT factory's internal XML parser and the ROS / DDS middleware layer.
+  // When always_reload_bt_ is true and the same BT is requested, only perform the full reload if at
+  // least one XML file on disk actually changed. Recreating the behaviour-tree (and its ROS
+  // interfaces) on every goal otherwise causes unbounded memory growth in both the BT factory's
+  // internal XML parser and the ROS / DDS middleware layer.
   if (always_reload_bt_ && current_bt_file_or_id_ == file_or_id) {
     bool any_changed = false;
     try {
@@ -277,10 +276,10 @@ bool BtActionServer<ActionT, NodeT>::loadBehaviorTree(const std::string & bt_xml
     RCLCPP_INFO(logger_, "BT XML file(s) modified on disk, reloading tree");
   }
 
-  // When reloading an already-loaded BT, clean up all resources before
-  // re-registering.  The BT factory's internal XML parser appends a new
-  // XMLDocument on each registerBehaviorTreeFromFile() call; clearing the
-  // parser state here keeps that list bounded and prevents a secondary leak.
+  // When reloading an already-loaded BT, clean up all resources before re-registering.
+  // The BT factory's internal XML parser appends a new XMLDocument on each
+  // registerBehaviorTreeFromFile() call, clearing the parser state here keeps that list bounded
+  // and prevents a secondary leak.
   if (!current_bt_file_or_id_.empty()) {
     topic_logger_.reset();
     bt_->haltAllActions(tree_);

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -433,16 +433,21 @@ bool BtActionServer<ActionT, NodeT>::loadBehaviorTree(const std::string & bt_xml
   // always_reload_bt_ can tell whether any XML actually changed.
   if (always_reload_bt_) {
     bt_xml_mtimes_.clear();
-    // Track the main file when it is specified as a path (not an ID)
-    if (!is_bt_id) {
-      bt_xml_mtimes_[file_or_id] = fs::last_write_time(file_or_id);
-    }
-    for (const auto & directory : search_directories_) {
-      for (const auto & entry : fs::directory_iterator(directory)) {
-        if (entry.path().extension() == ".xml") {
-          bt_xml_mtimes_[entry.path().string()] = fs::last_write_time(entry.path());
+    try {
+      if (!is_bt_id && fs::exists(file_or_id)) {
+        bt_xml_mtimes_[file_or_id] = fs::last_write_time(file_or_id);
+      }
+      for (const auto & directory : search_directories_) {
+        if (fs::exists(directory) && fs::is_directory(directory)) {
+          for (const auto & entry : fs::directory_iterator(directory)) {
+            if (entry.path().extension() == ".xml") {
+              bt_xml_mtimes_[entry.path().string()] = fs::last_write_time(entry.path());
+            }
+          }
         }
       }
+    } catch (const std::filesystem::filesystem_error & e) {
+      RCLCPP_WARN(logger_, "Failed to snapshot BT XML mtimes: %s", e.what());
     }
   }
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -258,7 +258,7 @@ bool BtActionServer<ActionT, NodeT>::loadBehaviorTree(const std::string & bt_xml
   // interfaces) on every goal otherwise causes unbounded memory growth in both the BT factory's
   // internal XML parser and the ROS / DDS middleware layer.
   if (always_reload_bt_ && current_bt_file_or_id_ == file_or_id) {
-    bool any_changed = false;
+    bool any_changed = bt_xml_mtimes_.empty(); // no snapshot: force reload
     try {
       for (const auto & [path, old_mtime] : bt_xml_mtimes_) {
         if (fs::last_write_time(path) != old_mtime) {
@@ -267,7 +267,7 @@ bool BtActionServer<ActionT, NodeT>::loadBehaviorTree(const std::string & bt_xml
         }
       }
     } catch (const std::filesystem::filesystem_error &) {
-      any_changed = true;  // file vanished or became inaccessible; force reload
+      any_changed = true; // file vanished or became inaccessible: force reload
     }
     if (!any_changed) {
       RCLCPP_DEBUG(logger_, "BT XML files unchanged on disk, skipping reload");

--- a/nav2_behavior_tree/src/behavior_tree_engine.cpp
+++ b/nav2_behavior_tree/src/behavior_tree_engine.cpp
@@ -180,6 +180,11 @@ void BehaviorTreeEngine::registerTreeFromFile(
   factory_.registerBehaviorTreeFromFile(file_path);
 }
 
+void BehaviorTreeEngine::clearRegisteredBehaviorTrees()
+{
+  factory_.clearRegisteredBehaviorTrees();
+}
+
 void
 BehaviorTreeEngine::addGrootMonitoring(
   BT::Tree * tree,


### PR DESCRIPTION
## Additions & Changes
Reduce memory leak when `always_reload_bt_xml` is `true`

1. When always_reload_bt_ is true and the same BT is requested, only perform the full reload if at least one XML file on disk actually changed. Recreating the BT (and its ROS interfaces) on every goal otherwise causes unbounded memory growth in both the BT factory's internal XML parser and the ROS / DDS middleware layer.

2. When reloading an already-loaded BT, clean up all resources before re-registering. The BT factory's internal XML parser appends a new XMLDocument on each registerBehaviorTreeFromFile() call, clearing the parser state here keeps that list bounded and prevents a secondary leak.

These changes do not fully fix the memory increase, but they greatly reduce it. Reloading is only done now if a file was changed during a run, which should only happen by developers and (theoretically) not hundreds of times.
It is still recommended to keep `always_reload_bt_xml` set to `false` unless otherwise needed.