### PR TITLE
MPPI: add arc-length path progress to fix path skipping on curved paths, PathAngleCritic: skip obstacles

### DIFF
--- a/nav2_mppi_controller/include/nav2_mppi_controller/tools/utils.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/tools/utils.hpp
@@ -282,40 +282,59 @@ auto shortest_angular_distance(
 }
 
 /**
- * @brief Evaluate furthest point idx of data.path which is
- * nearest to some trajectory in data.trajectories
+ * @brief Find the index of the furthest path point reached by a set
+ * of trajectories, where each trajectory's nearest-point search is
+ * restricted to path points within its own arc-length.
  * @param data Data to use
- * @return Idx of furthest path point reached by a set of trajectories
+ * @return Index of furthest path point reached by a set of trajectories
  */
 inline size_t findPathFurthestReachedPoint(const CriticData & data)
 {
-  int traj_cols = data.trajectories.x.cols();
-  const auto traj_x = data.trajectories.x.col(traj_cols - 1);
-  const auto traj_y = data.trajectories.y.col(traj_cols - 1);
+  const int traj_cols = data.trajectories.x.cols();
+  const int n_rows = static_cast<int>(data.trajectories.x.rows());
+  const int n_cols = static_cast<int>(data.path.x.size());
 
-  int max_id_by_trajectories = 0, min_id_by_path = 0;
-  float min_distance_by_path = std::numeric_limits<float>::max();
-  size_t n_rows = traj_x.rows();
-  size_t n_cols = data.path.x.size();
-  for (size_t i = 0; i != n_rows; i++) {
-    min_id_by_path = 0;
-    min_distance_by_path = std::numeric_limits<float>::max();
-    for (size_t j = 0; j != n_cols; j++) {
-      const float dx = data.path.x(j) - traj_x(i);
-      const float dy = data.path.y(j) - traj_y(i);
-      const float cur_dist = dx * dx + dy * dy;
-      if (cur_dist < min_distance_by_path) {
-        min_distance_by_path = cur_dist;
-        min_id_by_path = j;
-      }
-    }
-    max_id_by_trajectories = std::max(max_id_by_trajectories, min_id_by_path);
+  // Cumulative arc-lengths along the reference path
+  std::vector<float> path_integrated_dists(n_cols, 0.0f);
+  for (int i = 1; i < n_cols; ++i) {
+    const float dx = data.path.x(i) - data.path.x(i - 1);
+    const float dy = data.path.y(i) - data.path.y(i - 1);
+    path_integrated_dists[i] = path_integrated_dists[i - 1] + sqrtf(dx * dx + dy * dy);
+  }
+
+  // Arc-length of all candidate trajectories
+  const Eigen::ArrayXf traj_integrated_dists =
+    ((data.trajectories.x.rightCols(traj_cols - 1) -
+    data.trajectories.x.leftCols(traj_cols - 1)).square() +
+    (data.trajectories.y.rightCols(traj_cols - 1) -
+    data.trajectories.y.leftCols(traj_cols - 1)).square())
+    .sqrt().rowwise().sum();
+
+  const auto & traj_x_end = data.trajectories.x.col(traj_cols - 1);
+  const auto & traj_y_end = data.trajectories.y.col(traj_cols - 1);
+
+  int max_idx = 0;
+  for (int i = 0; i < n_rows; ++i) {
+    int max_reachable_idx = static_cast<int>(
+      std::lower_bound(
+        path_integrated_dists.begin(), path_integrated_dists.end(),
+        traj_integrated_dists(i)) - path_integrated_dists.begin());
+    max_reachable_idx = std::min(max_reachable_idx, n_cols - 1);
+
+    // Bounded Euclidean search: closest path point within [0..max_reachable_idx]
+    Eigen::Index eucl_idx;
+    ((data.path.x.head(max_reachable_idx + 1) - traj_x_end(i)).square() +
+    (data.path.y.head(max_reachable_idx + 1) - traj_y_end(i)).square()).minCoeff(&eucl_idx);
+
+    max_idx = std::max(max_idx, static_cast<int>(eucl_idx));
+
     // Early exit if we've already reached the end of the path
-    if (max_id_by_trajectories == static_cast<int>(n_cols) - 1) {
+    if (max_idx == n_cols - 1) {
       break;
     }
   }
-  return max_id_by_trajectories;
+
+  return static_cast<size_t>(max_idx);
 }
 
 /**

--- a/nav2_mppi_controller/src/critics/path_angle_critic.cpp
+++ b/nav2_mppi_controller/src/critics/path_angle_critic.cpp
@@ -79,16 +79,14 @@ void PathAngleCritic::score(CriticData & data)
   utils::setPathCostsIfNotSet(data, costmap_ros_);
   const size_t path_size = data.path.x.size() - 1;
 
-  auto offsetted_idx = std::min(*data.furthest_reached_path_point + offset_from_furthest_, path_size);
-
+  auto offsetted_idx = std::min(*data.furthest_reached_path_point + offset_from_furthest_,
+      path_size);
   // Drive to the first valid path point, in case of dynamic obstacles on path
   // we want to drive past it, not through it
   bool valid = false;
-  while (!valid && offsetted_idx < path_size - 1)
-  {
+  while (!valid && offsetted_idx < path_size - 1) {
     valid = (*data.path_pts_valid)[offsetted_idx];
-    if (!valid)
-    {
+    if (!valid) {
       offsetted_idx++;
     }
   }

--- a/nav2_mppi_controller/src/critics/path_angle_critic.cpp
+++ b/nav2_mppi_controller/src/critics/path_angle_critic.cpp
@@ -76,9 +76,22 @@ void PathAngleCritic::score(CriticData & data)
   }
 
   utils::setPathFurthestPointIfNotSet(data);
-  auto offsetted_idx = std::min(
-    *data.furthest_reached_path_point + offset_from_furthest_,
-    static_cast<size_t>(data.path.x.size()) - 1);
+  utils::setPathCostsIfNotSet(data, costmap_ros_);
+  const size_t path_size = data.path.x.size() - 1;
+
+  auto offsetted_idx = std::min(*data.furthest_reached_path_point + offset_from_furthest_, path_size);
+
+  // Drive to the first valid path point, in case of dynamic obstacles on path
+  // we want to drive past it, not through it
+  bool valid = false;
+  while (!valid && offsetted_idx < path_size - 1)
+  {
+    valid = (*data.path_pts_valid)[offsetted_idx];
+    if (!valid)
+    {
+      offsetted_idx++;
+    }
+  }
 
   const float goal_x = data.path.x(offsetted_idx);
   const float goal_y = data.path.y(offsetted_idx);

--- a/nav2_mppi_controller/test/utils_test.cpp
+++ b/nav2_mppi_controller/test/utils_test.cpp
@@ -254,8 +254,9 @@ TEST(UtilsTests, FurthestReachedPointUturn)
   generated_trajectories.yaws = Eigen::ArrayXXf::Zero(10, 4);
 
   CriticData data =
-  {state, generated_trajectories, path, goal, costs, model_dt, false, nullptr, nullptr,
-    std::nullopt, std::nullopt, {}};  /// Caution, keep references
+  {state, generated_trajectories, path, goal, costs, std::nullopt, model_dt, false, nullptr,
+    nullptr,
+    std::nullopt, std::nullopt};  /// Caution, keep references
 
   size_t result = findPathFurthestReachedPoint(data);
   EXPECT_LE(result, 6u);

--- a/nav2_mppi_controller/test/utils_test.cpp
+++ b/nav2_mppi_controller/test/utils_test.cpp
@@ -200,7 +200,8 @@ TEST(UtilsTests, FurthestAndClosestReachedPoint)
   EXPECT_EQ(data2.furthest_reached_path_point, 0);
 
   // Test the actual computation of the path point reached
-  generated_trajectories.x = Eigen::ArrayXXf::Ones(100, 2);
+  generated_trajectories.x = Eigen::ArrayXXf::Zero(100, 2);
+  generated_trajectories.x.col(1).setOnes();
   generated_trajectories.y = Eigen::ArrayXXf::Zero(100, 2);
   generated_trajectories.yaws = Eigen::ArrayXXf::Zero(100, 2);
 
@@ -217,6 +218,47 @@ TEST(UtilsTests, FurthestAndClosestReachedPoint)
     nullptr,
     std::nullopt, std::nullopt};  /// Caution, keep references
   EXPECT_EQ(findPathFurthestReachedPoint(data3), 5);
+}
+
+// Verify that the returned index of findPathFurthestReachedPoint() doesn't
+// exceed what is physically reachable (longest trajectory's arc-length)
+TEST(UtilsTests, FurthestReachedPointUturn)
+{
+  models::State state;
+  models::Trajectories generated_trajectories;
+  models::Path path;
+  geometry_msgs::msg::Pose goal;
+  Eigen::ArrayXf costs;
+  float model_dt = 0.1;
+
+  // U-turn path: (0, 0) to (8, 0), turn (8, 1), and go back to (0, 1)
+  const float path_x[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1, 0};
+  const float path_y[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+  nav_msgs::msg::Path plan;
+  plan.poses.resize(18);
+  for (unsigned int i = 0; i != 18; i++) {
+    plan.poses[i].pose.position.x = path_x[i];
+    plan.poses[i].pose.position.y = path_y[i];
+  }
+  path = toTensor(plan);
+
+  // 10 identical trajectories from (0,0) to (5,1), arc-length ~5.1m
+  generated_trajectories.x = Eigen::ArrayXXf::Zero(10, 4);
+  generated_trajectories.x.col(1).setConstant(5.0f / 3.0f);
+  generated_trajectories.x.col(2).setConstant(10.0f / 3.0f);
+  generated_trajectories.x.col(3).setConstant(5.0f);
+  generated_trajectories.y = Eigen::ArrayXXf::Zero(10, 4);
+  generated_trajectories.y.col(1).setConstant(1.0f / 3.0f);
+  generated_trajectories.y.col(2).setConstant(2.0f / 3.0f);
+  generated_trajectories.y.col(3).setConstant(1.0f);
+  generated_trajectories.yaws = Eigen::ArrayXXf::Zero(10, 4);
+
+  CriticData data =
+  {state, generated_trajectories, path, goal, costs, model_dt, false, nullptr, nullptr,
+    std::nullopt, std::nullopt, {}};  /// Caution, keep references
+
+  size_t result = findPathFurthestReachedPoint(data);
+  EXPECT_LE(result, 6u);
 }
 
 TEST(UtilsTests, findPathCosts)


### PR DESCRIPTION
## Additions & Changes
1. Cherry-pick https://github.com/ros-navigation/navigation2/pull/6055  :  Improves `findPathFurthestReachedPoint` by bounding the Euclidean search region to the candidate trajectory integrated-length. Prevents the Euclidean nearest-point match from jumping ahead on curved paths (e.g. U-turns).

2. `PathAngleCritic`: move reference point beyond dynamic obstacles, similar to `PathFollowCritic`

## How to test & expected outcomes

Together with PR in main repo
